### PR TITLE
Move farzadi postproc from 'cummins' to 'farzadi'

### DIFF
--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -1787,11 +1787,6 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
 
     dirichletfunc_ = NULL;
 
-    post_proc.push_back(new post_process(Comm,mesh_,(int)0));
-    post_proc[0].postprocfunc_ = &tpetra::farzadi3d::postproc_c_;
-    post_proc.push_back(new post_process(Comm,mesh_,(int)1));
-    post_proc[1].postprocfunc_ = &tpetra::farzadi3d::postproc_t_;
-
     neumannfunc_ = NULL;
 
     paramfunc_.resize(1);
@@ -1821,6 +1816,11 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     (*varnames_)[1] = "phi";
 
     dirichletfunc_ = NULL;
+
+    post_proc.push_back(new post_process(Comm,mesh_,(int)0));
+    post_proc[0].postprocfunc_ = &tpetra::farzadi3d::postproc_c_;
+    post_proc.push_back(new post_process(Comm,mesh_,(int)1));
+    post_proc[1].postprocfunc_ = &tpetra::farzadi3d::postproc_t_;
 
     paramfunc_.resize(1);
     paramfunc_[0] = &tpetra::farzadi3d::param_;


### PR DESCRIPTION
It looks like the changes from 29ece38a56e06237f5b3fce84350d183cacf7127 to add the postprocesssed fields for the regular farzadi test case (as opposed to farzadi_test) were added to the "cummins" section. This does not add the expected postprocessed output. Moving them to the next section for farzadi (starting on what is now line 1795) does.