### PR TITLE
fix scaling in heat::prec_heat_test_ and goldak::dfldt_coupled

### DIFF
--- a/timestep/include/function_def.hpp
+++ b/timestep/include/function_def.hpp
@@ -7621,7 +7621,11 @@ namespace radconvbc
   
   double deltau_h = 1.;
   double uref_h = 0.;
-
+  
+  double k_h = 1.0;
+  
+  double scaling_constant = 1.0;
+  
 DBC_FUNC(dbc_) 
 {
   return 1173.;
@@ -7639,9 +7643,14 @@ NBC_FUNC_TPETRA(nbc_)
   const double f[3] = {(h*(ti-u)+ep*sigma*(ti*ti*ti*ti-u*u*u*u))*test,
 		       (h*(ti-uold)+ep*sigma*(ti*ti*ti*ti-uold*uold*uold*uold))*test,
 		       (h*(ti-uoldold)+ep*sigma*(ti*ti*ti*ti-uoldold*uoldold*uoldold*uoldold))*test};
-  return (1.-t_theta2_)*t_theta_*f[0]
+  
+  const double coef = k_h * deltau_h / W0_h;
+  
+  const double rv = (1.-t_theta2_)*t_theta_*f[0]
     +(1.-t_theta2_)*(1.-t_theta_)*f[1]
     +.5*t_theta2_*((2.+dt_/dtold_)*f[1]-dt_/dtold_*f[2]);
+  
+  return rv * coef * scaling_constant;
 }
 
 INI_FUNC(init_heat_)
@@ -7657,6 +7666,12 @@ PARAM_FUNC(param_)
   ti = plist->get<double>("ti_",323.);
   deltau_h = plist->get<double>("deltau_",1.);
   uref_h = plist->get<double>("uref_",0.);
+  
+  W0_h = plist->get<double>("W0_",1.);
+  k_h = plist->get<double>("k_",1.);
+ 
+  scaling_constant = plist->get<double>("scaling_constant_",1.);
+
 //   std::cout<<"tpetra::radconvbc::param_:"<<std::endl
 // 	   <<"  h     = "<<h<<std::endl
 // 	   <<"  ep    = "<<ep<<std::endl

--- a/timestep/include/function_def.hpp
+++ b/timestep/include/function_def.hpp
@@ -7621,9 +7621,7 @@ namespace radconvbc
   
   double deltau_h = 1.;
   double uref_h = 0.;
-  
-  double k_h = 1.0;
-  
+    
   double scaling_constant = 1.0;
   
 DBC_FUNC(dbc_) 
@@ -7644,7 +7642,7 @@ NBC_FUNC_TPETRA(nbc_)
 		       (h*(ti-uold)+ep*sigma*(ti*ti*ti*ti-uold*uold*uold*uold))*test,
 		       (h*(ti-uoldold)+ep*sigma*(ti*ti*ti*ti-uoldold*uoldold*uoldold*uoldold))*test};
   
-  const double coef = k_h * deltau_h / W0_h;
+  const double coef = deltau_h / W0_h;
   
   const double rv = (1.-t_theta2_)*t_theta_*f[0]
     +(1.-t_theta2_)*(1.-t_theta_)*f[1]
@@ -7668,7 +7666,6 @@ PARAM_FUNC(param_)
   uref_h = plist->get<double>("uref_",0.);
   
   W0_h = plist->get<double>("W0_",1.);
-  k_h = plist->get<double>("k_",1.);
  
   scaling_constant = plist->get<double>("scaling_constant_",1.);
 

--- a/timestep/include/function_def.hpp
+++ b/timestep/include/function_def.hpp
@@ -5807,8 +5807,8 @@ RES_FUNC_TPETRA((*residual_heat_test_dp_)) = residual_heat_test_;
 KOKKOS_INLINE_FUNCTION 
 PRE_FUNC_TPETRA(prec_heat_test_)
 {
-  return rho_d*cp_d*basis[eqn_id].phi[j]/dt_*basis[eqn_id].phi[i]
-    + t_theta_*k_d*(basis[eqn_id].dphidx[j]*basis[eqn_id].dphidx[i]
+  return rho_d*cp_d/tau0_d*deltau_d*basis[eqn_id].phi[j]/dt_*basis[eqn_id].phi[i]
+    + t_theta_*k_d/W0_d/W0_d*deltau_d*(basis[eqn_id].dphidx[j]*basis[eqn_id].dphidx[i]
        + basis[eqn_id].dphidy[j]*basis[eqn_id].dphidy[i]
        + basis[eqn_id].dphidz[j]*basis[eqn_id].dphidz[i]);
 }
@@ -7727,7 +7727,7 @@ void dfldt_uncoupled(GPUBasis * basis[], const int index, const double dt_, cons
 KOKKOS_INLINE_FUNCTION 
 void dfldt_coupled(GPUBasis * basis[], const int index, const double dt_, const double dtold_, double *a)
 {
-  const double coef = Lf/(tl-te)/tpetra::heat::cp_d;
+  double coef = tpetra::heat::rho_d*tpetra::goldak::Lf/tau0_d;
   const double dfldu_d[3] = {-.5*coef,-.5*coef,-.5*coef};
 
   a[0] = ((1. + dt_/dtold_)*(dfldu_d[0]*basis[index]->uu-dfldu_d[1]*basis[index]->uuold)/dt_


### PR DESCRIPTION
Fixes two scaling issues:
1) The preconditioner for the heat equation was missing some constants in the scaling factor that are present in the RHS
2) The scaling of dfldt_coupled doesn't account for the factor of rho * C_p * DeltaT_0 / tau_0 that was applied to the entire RHS