### PR TITLE
WIP: Fix farzadi conservation bug

### DIFF
--- a/timestep/include/function_def.hpp
+++ b/timestep/include/function_def.hpp
@@ -1371,7 +1371,7 @@ RES_FUNC(residual_conc_farzadi_)
   double dphidx = basis[1].dudx;
   double dphidy = basis[1].dudy;
 
-  double ut = (1.+k_)/2.*(u-uold)/dt_*test;
+  double ut = (1.+k_-(1.0-k_)*phi)/2.*(u-uold)/dt_*test;
   //ut = (u-uold)/dt_*test;
   double divgradu = D*(1.-phi)/2.*(basis[0].dudx*dtestdx + basis[0].dudy*dtestdy);//(grad u,grad phi)
   //divgradu = (basis[0].dudx*dtestdx + basis[0].dudy*dtestdy);
@@ -6337,7 +6337,8 @@ RES_FUNC_TPETRA(residual_conc_farzadi_)
   const double dphidy[3] = {basis[phi_id]->dudy,basis[phi_id]->duolddy,basis[phi_id]->duoldolddy};
   const double dphidz[3] = {basis[phi_id]->dudz,basis[phi_id]->duolddz,basis[phi_id]->duoldolddz};
 
-  const double ut = (1.+k)/2.*(u[0]-u[1])/dt_*test;
+  const double ut = (1. + k - (1.0 - k) * phi[0]) / 2. * (u[0] - u[1]) / dt_ * test;
+
   const double divgradu[3] = {D_liquid_*(1.-phi[0])/2.*(basis[eqn_id]->dudx*dtestdx + basis[eqn_id]->dudy*dtestdy + basis[eqn_id]->dudz*dtestdz),
 			      D_liquid_*(1.-phi[1])/2.*(basis[eqn_id]->duolddx*dtestdx + basis[eqn_id]->duolddy*dtestdy + basis[eqn_id]->duolddz*dtestdz),
 			      D_liquid_*(1.-phi[2])/2.*(basis[eqn_id]->duoldolddx*dtestdx + basis[eqn_id]->duoldolddy*dtestdy + basis[eqn_id]->duoldolddz*dtestdz)};//(grad u,grad phi)
@@ -6674,7 +6675,7 @@ RES_FUNC_TPETRA(residual_conc_farzadi_exp_)
   const double dphidy[2] = {basis[1]->dudy,basis[1]->duolddy};
   const double dphidz[2] = {basis[1]->dudz,basis[1]->duolddz};
 
-  const double ut = (1.+k)/2.*(u[0]-u[1])/dt_*test;
+  const double ut = (1.+k-(1.0-k)*phi[0])/2.*(u[0]-u[1])/dt_*test;
   const double divgradu[2] = {D_liquid_*(1.-phi[0])/2.*(basis[0]->dudx*dtestdx + basis[0]->dudy*dtestdy + basis[0]->dudz*dtestdz),
 			      D_liquid_*(1.-phi[1])/2.*(basis[0]->duolddx*dtestdx + basis[0]->duolddy*dtestdy + basis[0]->duolddz*dtestdz)};//(grad u,grad phi)
 


### PR DESCRIPTION
@chrisknewman I believe that I found the source of the conservation bug for farzadi calculations.

Here's the governing equation for the evolution of U:
<img width="570" alt="image" src="https://github.com/chrisknewman/tusas/assets/10517751/e86747d6-f6ad-4ccd-abb5-ba3e722e2ce2">

The issue was in the right-most term. The residual for the concentration didn't have a chain-rule term for U. That is, that term is equivalent to:
$$\frac{1}{2} \left[ \frac{\partial \phi}{\partial t} \left(1+(1-k)U \right)\right] + \frac{1}{2} \left[ \phi (1-k) \frac{\partial U}{\partial t}\right]$$

The code had the first of these terms, but not the second. I moved the second term over into `ut`. I also made the changes in the old farzadi code and the explicit residual.

We now get something that looks like the expected result:
<img width="500" alt="image" src="https://github.com/chrisknewman/tusas/assets/10517751/80505a6f-439d-4504-a48a-ba6a5fc158e6">

There's some minor loss of conservation, but I think that is for the normal reasons of a nonconservative discretization. The result is close to what I get with PRISMS-PF, but there are some differences. That could simply be due to discretization error or tolerances being too loose.

I listed this as "Work In Progress" because there are still a few things to work out:
- This domain wasn't big enough to get to a true steady state. I need to do a bigger/longer test.
- I'm still confirming that with this fix Tusas converges to the same solution as PRISMS-PF.
- I'm not sure if the preconditioner fills need updating. Do you think they do?
- The regression tests will need updating. I'm having issues running the tests locally and have some questions for you at our next meeting.


