### PR TITLE
Add bool to disable temp variables write to exodus

### DIFF
--- a/Test/RobinHex/exofile
+++ b/Test/RobinHex/exofile
@@ -1,9 +1,9 @@
 NODAL VARIABLES all
-	grad0x floor 1.e-13
-	grad0y relative 1.7E-05 floor 1.e-9
-	grad0z relative 3.3E-06  floor 3.e-9
+	!grad0x
+	!grad0y
+	!grad0z
 	u floor 1.e-17
 ELEMENT VARIABLES all
 	!color
-	error0 floor 3.e-9
+	!error0
 	!processor_id

--- a/Test/Thermal/exofile
+++ b/Test/Thermal/exofile
@@ -1,5 +1,7 @@
 TIME STEPS relative 5.5e-13 floor 1e-11
 NODAL VARIABLES
-	temperror0 relative 1.E-04 floor 1.e-8
+	!temperror0
+	!tempnorm0
+	!tempdyn0
 #ELEMENT VARIABLES
 	!color

--- a/post_process/include/post_process.h
+++ b/post_process/include/post_process.h
@@ -51,8 +51,8 @@ public:
 	       bool restart = false, ///< restart bool
 	       const int eqn_id = 0, ///< associate this post process variable with an equation
 	       const std::string basename = "pp", ///< basename this post process variable
-	       const int precision = 6 ///< precision for output file
-	       );
+	       const int precision = 6, ///< precision for output file
+	       const bool writedata = true); ///< whether to write field to exodus
   /// Destructor
   ~post_process();
   /// Write the post process variable to exodus.
@@ -127,8 +127,8 @@ private:
   std::string basename_;
   /// restart boolean
   bool restart_;
-  /// write files boolean
-  //bool write_files_;
+  /// write data boolean
+  bool writedata_;
 
 };
 

--- a/post_process/post_process.cpp
+++ b/post_process/post_process.cpp
@@ -26,15 +26,18 @@ post_process::post_process(//const Teuchos::RCP<const Epetra_Comm>& comm,
 			   bool restart,
 			   const int eqn_id,
 			   const std::string basename,
-			   const int precision):  
+			   const int precision,
+               const bool writedata):
   mesh_(mesh),
   index_(index),
   s_op_(s_op),
   restart_(restart),
   eqn_id_(eqn_id),
   basename_(basename),
-  precision_(precision)
+  precision_(precision),
+  writedata_(writedata)
 {
+
   scalar_val_ =  0.;
 
   const std::vector<Mesh::mesh_lint_t> node_num_map(mesh_->get_node_num_map());
@@ -66,7 +69,7 @@ post_process::post_process(//const Teuchos::RCP<const Epetra_Comm>& comm,
   ppvar_ = Teuchos::rcp(new vector_type(node_map_));
 
   const std::string ystring=basename_+std::to_string(index_);
-  mesh_->add_nodal_field(ystring);
+  if(writedata_) mesh_->add_nodal_field(ystring);
 
   if ( (0 == comm_->getRank()) && (s_op_ != NONE) ){
     filename_ = ystring+".dat";
@@ -80,7 +83,9 @@ post_process::post_process(//const Teuchos::RCP<const Epetra_Comm>& comm,
   }
 
   if ( 0 == comm_->getRank())
-    std::cout<<"Post process created for variable "<<index_<<" with name "<<ystring<<std::endl<<std::endl;
+    std::cout<<"Post process created for variable "<<index_
+             <<" with name "<<ystring
+             <<". Write to exodus = "<<writedata_<<std::endl<<std::endl;
   //exit(0);
 };
 
@@ -109,6 +114,8 @@ void post_process::process(const int i,
 };
 
 void post_process::update_mesh_data() const {
+
+  if(!writedata_) return;
 
   const int num_nodes = overlap_map_->getLocalNumElements();
 

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -4094,7 +4094,8 @@ void ModelEvaluatorTPETRA<Scalar>::setadaptivetimestep()
 					      dorestart, 
 					      k, 
 					      "temperror",
-					      16));
+					      16,
+                          false));
       //be with an error estimate based on second derivative
       if(atsList->get<std::string> (TusasatstypeNameString) == "second derivative")
 	temporal_est[k].postprocfunc_ = &timeadapt::d2udt2_;
@@ -4122,7 +4123,8 @@ void ModelEvaluatorTPETRA<Scalar>::setadaptivetimestep()
 					       dorestart,
 					       k, 
 					       "tempnorm",
-					       16));
+					       16,
+                           false));
       temporal_norm[k].postprocfunc_ = &timeadapt::normu_;
 
       temporal_dyn.push_back(new post_process(
@@ -4132,7 +4134,8 @@ void ModelEvaluatorTPETRA<Scalar>::setadaptivetimestep()
 					       dorestart,
 					       k, 
 					       "tempdyn",
-					       16));
+					       16,
+                           false));
       temporal_dyn[k].postprocfunc_ = &timeadapt::dynamic_;
       
     }


### PR DESCRIPTION
This PR adds a switch to the post process routine that allows the user to select if a given variable is written to exodus or not. The bool defaults to true, but is manually set to false for temporary variables.