### PR TITLE
Port global variable functionality and disable optional variable write bools to crusher

### DIFF
--- a/elem_color/elem_color.cpp
+++ b/elem_color/elem_color.cpp
@@ -26,8 +26,10 @@
 std::string getmypidstring(const int mypid, const int numproc);
 
 elem_color::elem_color(Mesh *mesh,
-		       bool dorestart): 
-  mesh_(mesh)
+		       bool dorestart,
+               bool writedata): 
+  mesh_(mesh),
+  writedata_(writedata)
 {
   //ts_time_create= Teuchos::TimeMonitor::getNewTimer("Total Elem Create Color Time");
   //ts_time_elemadj= Teuchos::TimeMonitor::getNewTimer("Total Elem Adj Fill Time");
@@ -203,12 +205,14 @@ void elem_color::create_colorer()
 }
 void elem_color::init_mesh_data() const
 {
+  if (!writedata_) return;
   const std::string cstring="color";
   mesh_->add_elem_field(cstring);
   return;
 }
 void elem_color::update_mesh_data() const
 {
+  if (!writedata_) return;
   const int num_elem = mesh_->get_elem_num_map()->size();
   std::vector<double> color(num_elem,0.);
   for(int c = 0; c < num_color_; c++){

--- a/elem_color/include/elem_color.h
+++ b/elem_color/include/elem_color.h
@@ -33,7 +33,8 @@ class elem_color
 public:
   /// Constructor
   elem_color(Mesh *mesh, ///< mesh object
-	     bool dorestart = false ///< do restart
+	     bool dorestart = false, ///< do restart
+         bool writedata = false
 	     );
   ///Destructor
   ~elem_color();
@@ -79,6 +80,7 @@ private:
   //Teuchos::RCP<Teuchos::Time> ts_time_elemadj;
   Teuchos::RCP<Teuchos::Time> ts_time_color;
   //Teuchos::RCP<Teuchos::Time> ts_time_create;
+  bool writedata_;
 
 };
 #endif

--- a/mesh/Mesh.C
+++ b/mesh/Mesh.C
@@ -51,6 +51,7 @@ int Mesh::read_exodus(const char * filename){
   is_nodesets_sorted = false;
   is_compute_nodal_patch_overlap = false;
 
+  num_global_fields = 0;
   num_nodal_fields = 0;
   num_elem_fields = 0;
 
@@ -1256,6 +1257,22 @@ int Mesh::add_nodal_data(std::string &name, std::vector<double> &data){
 }
 */
 //int Mesh::add_nodal_data(std::basic_string<char, std::char_traits<char> > name, double *data){return 1;}
+
+int Mesh::add_global_field(const std::string name){
+    num_global_fields++;
+
+    global_field_names.push_back(name);
+    global_fields.resize(num_nodal_fields);
+    if(verbose)
+
+      std::cout<<"=== add global field ==="<<std::endl
+	       <<" num_global_fields "<<num_global_fields<<std::endl
+	       <<" sizeof global_field_names "<<global_field_names.size()<<std::endl
+	       <<" global_field_names "<<name<<std::endl;
+
+  return 1;
+
+}
 int Mesh::add_nodal_data(std::string name, std::vector<double> &data){
 
 

--- a/mesh/Mesh.C
+++ b/mesh/Mesh.C
@@ -974,28 +974,25 @@ int Mesh::write_element_blocks_exodus(int ex_id){
 
 int Mesh::write_global_data_exodus(int ex_id){
 
-  int ex_err;
-  char **var_names;
-
-  if(1)
+  if(verbose)
     std::cout<<"=== Write Global Data Exodus ==="<<std::endl
 	         <<" num_global_fields "<<num_global_fields<<std::endl;
 
   if(num_global_fields == 0) return 0;
 
-  ex_err = ex_put_var_param (ex_id, "G", num_global_fields);
+  int ex_err = ex_put_var_param (ex_id, "G", num_global_fields);
 
-  var_names = new char*[num_global_fields];
+  char **var_names = new char*[num_global_fields];
   for(int i = 0; i < num_global_fields; i++){
     var_names[i] = (char *)&global_field_names[i][0];
 
-    if(1)
+    if(verbose)
       std::cout<<" name  "<<var_names[i]<<std::endl<<std::endl;
   }
 
-  ex_err = ex_put_var_names (ex_id, "G", num_global_fields, var_names);
+  ex_err = ex_put_var_names(ex_id, "G", num_global_fields, var_names);
 
-  ex_err = ex_put_glob_vars (ex_id, 1, num_global_fields, &global_fields[0]);
+  ex_err = ex_put_glob_vars(ex_id, 1, num_global_fields, &global_fields[0]);
 
   delete [] var_names;
 
@@ -1005,37 +1002,30 @@ int Mesh::write_global_data_exodus(int ex_id){
 
 int Mesh::write_global_data_exodus(int ex_id, int counter){
 
-  int ex_err;
-  char **var_names;
-
-  if(1)
+  if(verbose)
     std::cout<<"=== Write Global Data Exodus 1==="<<std::endl
 	         <<" num_global_fields "<<num_global_fields<<std::endl;
 
   if(num_global_fields == 0) return 0;
 
-  ex_err = ex_put_var_param (ex_id, "G", num_global_fields);
+  int ex_err = ex_put_var_param (ex_id, "G", num_global_fields);
 
-  var_names = new char*[num_global_fields];
+  char **var_names = new char*[num_global_fields];
   std::vector<int> ex_index(num_global_fields);
   for(int i = 0; i < num_global_fields; i++){
     ex_index[i] = get_global_field_index(global_field_names[i]);
 
-    if( 0 > ex_index[i] ) ex_index[i] = i;
+    if(0 > ex_index[i]) ex_index[i] = i;
 
     var_names[ex_index[i]] = (char *)&global_field_names[i][0];
 
-    if(1)
+    if(verbose)
       std::cout<<" name  "<<var_names[i]<<std::endl<<std::endl;
   }
 
-  ex_err = ex_put_var_names (ex_id, "G", num_global_fields, var_names);
+  ex_err = ex_put_var_names(ex_id, "G", num_global_fields, var_names);
 
-  ex_err = ex_put_glob_vars (ex_id, counter, num_global_fields, &global_fields[0]);
-  std::cout<<"ex_err "<<ex_err<<std::endl;
-  std::cout<<"global_fields[0] "<<global_fields[0]<<std::endl;
-  std::cout<<"&global_fields[0] "<<&global_fields[0]<<std::endl;
-  std::cout<<"&global_fields "<<&global_fields<<std::endl;
+  ex_err = ex_put_glob_vars(ex_id, counter, num_global_fields, &global_fields[0]);
 
   delete [] var_names;
 
@@ -1226,7 +1216,7 @@ int Mesh::read_num_proc_nemesis(int ex_id, int *nproc){
 
 int Mesh::read_global_data_exodus(const int ex_id, const int timestep, std::string name, double *data){
 
-  int ex_err = ex_get_glob_vars (ex_id, timestep, num_global_fields, &global_fields[0]);
+  int ex_err = ex_get_glob_vars(ex_id, timestep, num_global_fields, &global_fields[0]);
 
   const int index = get_global_field_index(name);
   *data = global_fields[index];
@@ -1253,8 +1243,6 @@ int Mesh::get_global_field_index(std::string name){
   for (int i = 0; i < num_global_fields; i++){
     if(name == global_field_names[i]) index = i;
   }
-
-  std::cout<<"index "<<index<<std::endl;
 
   return index;
 }
@@ -1360,20 +1348,21 @@ int Mesh::add_nodal_data(std::string &name, std::vector<double> &data){
 //int Mesh::add_nodal_data(std::basic_string<char, std::char_traits<char> > name, double *data){return 1;}
 
 int Mesh::add_global_field(const std::string name){
-    num_global_fields++;
 
+    num_global_fields++;
     global_field_names.push_back(name);
     global_fields.resize(num_nodal_fields);
-    if(verbose)
 
+    if(verbose)
       std::cout<<"=== add global field ==="<<std::endl
-	       <<" num_global_fields "<<num_global_fields<<std::endl
-	       <<" sizeof global_field_names "<<global_field_names.size()<<std::endl
-	       <<" global_field_names "<<name<<std::endl;
+	           <<" num_global_fields "<<num_global_fields<<std::endl
+	           <<" sizeof global_field_names "<<global_field_names.size()<<std::endl
+	           <<" global_field_names "<<name<<std::endl;
 
   return 1;
 
 }
+
 int Mesh::add_nodal_data(std::string name, std::vector<double> &data){
 
 
@@ -1428,10 +1417,7 @@ int Mesh::update_global_data(const std::string name, const double data){
 
   for (int i = 0; i < num_global_fields; i++){
     if(name == global_field_names[i]){
-      //std::cout<<"found"<<std::endl;
-      std::cout<<"data "<<data<<std::endl;
       global_fields[i]=data;
-      //for(int j = 0; j<(nodal_fields[i]).size();j++ ) std::cout<<proc_id<<" "<<(nodal_fields[i]).size()<<" "<<num_nodes<<" "<<j<<" "<<nodal_fields[i][j]<<std::endl;
       return 1;
     }
   }

--- a/mesh/Mesh.C
+++ b/mesh/Mesh.C
@@ -1055,8 +1055,8 @@ int Mesh::write_elem_data_exodus(int ex_id){
 
   if(verbose)
 
-    std::cout<<"=== Write Nodal Data Exodus ==="<<std::endl
-	     <<" num_nodal_fields "<<num_nodal_fields<<std::endl;
+    std::cout<<"=== Write Element Data Exodus ==="<<std::endl
+	     <<" num_elem_fields "<<num_elem_fields<<std::endl;
 
   if(num_elem_fields == 0) return 0;
 
@@ -1100,8 +1100,8 @@ int Mesh::write_elem_data_exodus(int ex_id, int counter){
 
   if(verbose)
 
-    std::cout<<"=== Write Nodal Data Exodus ==="<<std::endl
-	     <<" num_nodal_fields "<<num_nodal_fields<<std::endl;
+    std::cout<<"=== Write Element Data Exodus ==="<<std::endl
+	     <<" num_elem_fields "<<num_nodal_fields<<std::endl;
 
   if(num_elem_fields == 0) return 0;
 

--- a/mesh/Mesh.C
+++ b/mesh/Mesh.C
@@ -1019,7 +1019,7 @@ int Mesh::write_global_data_exodus(int ex_id, int counter){
   var_names = new char*[num_global_fields];
   std::vector<int> ex_index(num_global_fields);
   for(int i = 0; i < num_global_fields; i++){
-    ex_index[i] = read_global_field_index(ex_id, global_field_names[i]);
+    ex_index[i] = get_global_field_index(global_field_names[i]);
 
     if( 0 > ex_index[i] ) ex_index[i] = i;
 
@@ -1224,6 +1224,16 @@ int Mesh::read_num_proc_nemesis(int ex_id, int *nproc){
   return ex_err;
 }
 
+int Mesh::read_global_data_exodus(const int ex_id, const int timestep, std::string name, double *data){
+
+  int ex_err = ex_get_glob_vars (ex_id, timestep, num_global_fields, &global_fields[0]);
+
+  const int index = get_global_field_index(name);
+  *data = global_fields[index];
+
+  return ex_err;
+}
+
 int Mesh::read_nodal_data_exodus(const int ex_id, const int timestep, const int index, double *data){
   int ex_err = ex_get_nodal_var (ex_id, timestep, index, num_nodes, &data[0]);
   return ex_err;
@@ -1236,37 +1246,16 @@ int Mesh::read_nodal_data_exodus(const int ex_id, const int timestep, std::strin
   return ex_err;
 }
 
-int Mesh::read_global_field_index(const int ex_id, std::string name){
-  //cn this should be the index in the exodus file, since we have not populated these names yet
+int Mesh::get_global_field_index(std::string name){
 
   int index = -1;
 
-  int num_global_vars;
-  int error = ex_get_var_param (ex_id, "G" , &num_global_vars);
-
-  //std::cout<<num_node_vars<<std::endl;
-
-  char ** var_names;
-  var_names = new char*[num_global_vars];
-  for (int i = 0; i < num_global_vars; i++) var_names[i] = new char[TUSAS_MAX_LINE_LENGTH];
-
-
-  error = ex_get_var_names (ex_id, "G", num_global_vars, var_names);
-  for (int i = 0; i < num_global_vars; i++){
-    //std::cout<<std::string(var_names[i])<<std::endl;
-    if( name == std::string(var_names[i])) index = i;
+  for (int i = 0; i < num_global_fields; i++){
+    if(name == global_field_names[i]) index = i;
   }
 
-  for (int i = 0; i < num_global_vars; i++) delete [] var_names[i];
-  delete [] var_names;
-
-//   if(0 > index){
-//     std::cout<<name<<" not found"<<std::endl<<std::endl;
-//     exit(0);
-//   }
   std::cout<<"index "<<index<<std::endl;
 
-  //exit(0);
   return index;
 }
 

--- a/mesh/Mesh.C
+++ b/mesh/Mesh.C
@@ -706,6 +706,7 @@ int Mesh::write_exodus(const char * filename){
 
    write_nodal_coordinates_exodus(ex_id);
    write_element_blocks_exodus(ex_id);
+   write_global_data_exodus(ex_id);
    write_nodal_data_exodus(ex_id);
 
 return 0;
@@ -718,6 +719,7 @@ int Mesh::write_exodus(const int ex_id){
 
    write_nodal_coordinates_exodus(ex_id);
    write_element_blocks_exodus(ex_id);
+   write_global_data_exodus(ex_id);
    write_nodal_data_exodus(ex_id);
    write_elem_data_exodus(ex_id);
    //ex_put_node_num_map(ex_id,&node_num_map[0]);
@@ -732,7 +734,10 @@ int Mesh::write_exodus(const int ex_id, const int counter, const double time){
   //std::cout<<error<<std::endl;
   error = write_element_blocks_exodus(ex_id);
   //std::cout<<error<<std::endl;
+  error = write_global_data_exodus(ex_id,counter);
+  //std::cout<<error<<std::endl;
   error = write_nodal_data_exodus(ex_id,counter);
+  //std::cout<<error<<std::endl;
   error = write_elem_data_exodus(ex_id,counter);
   //std::cout<<error<<std::endl;
   error = ex_put_time(ex_id,counter,&time);
@@ -747,6 +752,8 @@ int Mesh::write_exodus_no_elem(const int ex_id, const int counter, const double 
   error = write_nodal_coordinates_exodus(ex_id);
   //std::cout<<error<<std::endl;
   error = write_element_blocks_exodus(ex_id);
+  //std::cout<<error<<std::endl;
+  error = write_global_data_exodus(ex_id,counter);
   //std::cout<<error<<std::endl;
   error = write_nodal_data_exodus(ex_id,counter);
   //error = write_elem_data_exodus(ex_id,counter);
@@ -965,6 +972,77 @@ int Mesh::write_element_blocks_exodus(int ex_id){
 
 }
 
+int Mesh::write_global_data_exodus(int ex_id){
+
+  int ex_err;
+  char **var_names;
+
+  if(1)
+    std::cout<<"=== Write Global Data Exodus ==="<<std::endl
+	         <<" num_global_fields "<<num_global_fields<<std::endl;
+
+  if(num_global_fields == 0) return 0;
+
+  ex_err = ex_put_var_param (ex_id, "G", num_global_fields);
+
+  var_names = new char*[num_global_fields];
+  for(int i = 0; i < num_global_fields; i++){
+    var_names[i] = (char *)&global_field_names[i][0];
+
+    if(1)
+      std::cout<<" name  "<<var_names[i]<<std::endl<<std::endl;
+  }
+
+  ex_err = ex_put_var_names (ex_id, "G", num_global_fields, var_names);
+
+  ex_err = ex_put_glob_vars (ex_id, 1, num_global_fields, &global_fields[0]);
+
+  delete [] var_names;
+
+  return ex_err;
+
+}
+
+int Mesh::write_global_data_exodus(int ex_id, int counter){
+
+  int ex_err;
+  char **var_names;
+
+  if(1)
+    std::cout<<"=== Write Global Data Exodus 1==="<<std::endl
+	         <<" num_global_fields "<<num_global_fields<<std::endl;
+
+  if(num_global_fields == 0) return 0;
+
+  ex_err = ex_put_var_param (ex_id, "G", num_global_fields);
+
+  var_names = new char*[num_global_fields];
+  std::vector<int> ex_index(num_global_fields);
+  for(int i = 0; i < num_global_fields; i++){
+    ex_index[i] = read_global_field_index(ex_id, global_field_names[i]);
+
+    if( 0 > ex_index[i] ) ex_index[i] = i;
+
+    var_names[ex_index[i]] = (char *)&global_field_names[i][0];
+
+    if(1)
+      std::cout<<" name  "<<var_names[i]<<std::endl<<std::endl;
+  }
+
+  ex_err = ex_put_var_names (ex_id, "G", num_global_fields, var_names);
+
+  ex_err = ex_put_glob_vars (ex_id, counter, num_global_fields, &global_fields[0]);
+  std::cout<<"ex_err "<<ex_err<<std::endl;
+  std::cout<<"global_fields[0] "<<global_fields[0]<<std::endl;
+  std::cout<<"&global_fields[0] "<<&global_fields[0]<<std::endl;
+  std::cout<<"&global_fields "<<&global_fields<<std::endl;
+
+  delete [] var_names;
+
+  return ex_err;
+
+}
+
 int Mesh::write_nodal_data_exodus(int ex_id){
 
   int ex_err;
@@ -1158,6 +1236,40 @@ int Mesh::read_nodal_data_exodus(const int ex_id, const int timestep, std::strin
   return ex_err;
 }
 
+int Mesh::read_global_field_index(const int ex_id, std::string name){
+  //cn this should be the index in the exodus file, since we have not populated these names yet
+
+  int index = -1;
+
+  int num_global_vars;
+  int error = ex_get_var_param (ex_id, "G" , &num_global_vars);
+
+  //std::cout<<num_node_vars<<std::endl;
+
+  char ** var_names;
+  var_names = new char*[num_global_vars];
+  for (int i = 0; i < num_global_vars; i++) var_names[i] = new char[TUSAS_MAX_LINE_LENGTH];
+
+
+  error = ex_get_var_names (ex_id, "G", num_global_vars, var_names);
+  for (int i = 0; i < num_global_vars; i++){
+    //std::cout<<std::string(var_names[i])<<std::endl;
+    if( name == std::string(var_names[i])) index = i;
+  }
+
+  for (int i = 0; i < num_global_vars; i++) delete [] var_names[i];
+  delete [] var_names;
+
+//   if(0 > index){
+//     std::cout<<name<<" not found"<<std::endl<<std::endl;
+//     exit(0);
+//   }
+  std::cout<<"index "<<index<<std::endl;
+
+  //exit(0);
+  return index;
+}
+
 int Mesh::read_nodal_field_index(const int ex_id, std::string name){
   //cn this should be the index in the exodus file, since we have not populated these names yet
 
@@ -1323,6 +1435,29 @@ int Mesh::add_elem_field(const std::string name){
 
 }
 
+int Mesh::update_global_data(const std::string name, const double data){
+
+  for (int i = 0; i < num_global_fields; i++){
+    if(name == global_field_names[i]){
+      //std::cout<<"found"<<std::endl;
+      std::cout<<"data "<<data<<std::endl;
+      global_fields[i]=data;
+      //for(int j = 0; j<(nodal_fields[i]).size();j++ ) std::cout<<proc_id<<" "<<(nodal_fields[i]).size()<<" "<<num_nodes<<" "<<j<<" "<<nodal_fields[i][j]<<std::endl;
+      return 1;
+    }
+  }
+
+  if(verbose)
+    std::cout<<"=== Update global data ==="<<std::endl
+	         <<" num_global_fields "<<num_global_fields<<std::endl
+	         <<" sizeof global_field_names "<<global_field_names.size()<<std::endl
+	         <<" sizeof global_fields "<<global_fields.size()<<std::endl<<std::endl;
+
+  std::cout<<name<<" not found"<<std::endl<<std::endl;
+
+  return 0;
+
+}
 
 int Mesh::update_nodal_data(const std::string name, const double *data){
 

--- a/mesh/include/Mesh.h
+++ b/mesh/include/Mesh.h
@@ -76,6 +76,8 @@ class Mesh
   int read_time_exodus(const int ex_id, const int counter, double &time);
   /// Read the last timestep index timestep from exodus file with exodus id ex_id.
   int read_last_step_exodus(const int ex_id, int &timestep);
+  /// Read global data by variable name name at timestep index timestep.
+  int read_global_data_exodus(const int ex_id, const int timestep, std::string name, double *data);
   /// Read nodal data by variable index index at timestep index timestep.
   int read_nodal_data_exodus(const int ex_id, const int timestep, const int index, double *data);
   /// Read nodal data by variable name name at timestep index timestep.
@@ -311,8 +313,8 @@ class Mesh
   int write_elem_data_exodus(int ex_id, int counter);
   int write_elem_data_exodus(int ex_id);
   void check_exodus_error(const int ex_err,const std::string msg);
+  int get_global_field_index(std::string name);
   int get_nodal_field_index(std::string name);
-  int read_global_field_index(const int ex_id, std::string name);
   int read_nodal_field_index(const int ex_id, std::string name);
   int get_elem_field_index(std::string name);
   //std::vector<int> node_num_map;

--- a/mesh/include/Mesh.h
+++ b/mesh/include/Mesh.h
@@ -108,6 +108,8 @@ class Mesh
   int add_nodal_data(std::string name, double *data);
   /// Add nodal field with name name
   int add_nodal_field(const std::string name);
+  /// Update global data as a double with name name
+  int update_global_data(const std::string name, const double data);
   /// Update nodal data as an array with name name
   int update_nodal_data(const std::string name, const double *data);
   /// Add an element field with name name
@@ -302,12 +304,15 @@ class Mesh
 
   int write_nodal_coordinates_exodus(int ex_id);
   int write_element_blocks_exodus(int ex_id);
+  int write_global_data_exodus(int ex_id);
+  int write_global_data_exodus(int ex_id, int counter);
   int write_nodal_data_exodus(int ex_id);
   int write_nodal_data_exodus(int ex_id, int counter);
   int write_elem_data_exodus(int ex_id, int counter);
   int write_elem_data_exodus(int ex_id);
   void check_exodus_error(const int ex_err,const std::string msg);
   int get_nodal_field_index(std::string name);
+  int read_global_field_index(const int ex_id, std::string name);
   int read_nodal_field_index(const int ex_id, std::string name);
   int get_elem_field_index(std::string name);
   //std::vector<int> node_num_map;

--- a/mesh/include/Mesh.h
+++ b/mesh/include/Mesh.h
@@ -100,6 +100,8 @@ class Mesh
   std::vector<int> get_nodal_patch(int i){return nodal_patch[i];}
   std::vector<int> get_nodal_patch_overlap(int i){return nodal_patch_overlap[i];}
 
+  /// Add global field with name name
+  int add_global_field(const std::string name);
   /// Add nodal data as std::vector<double> with name name
   int add_nodal_data(std::string name, std::vector<double> &data);
   /// Add nodal data as an array with name name
@@ -251,6 +253,7 @@ class Mesh
   int num_elem_blk;
   int num_node_sets;
   int num_side_sets;
+  int num_global_fields;
   int num_nodal_fields;
   int num_elem_fields;
   int num_vertices;
@@ -285,6 +288,9 @@ class Mesh
   std::vector<std::vector<int> > nodal_adj; //cn we may only need this for epetra
   //std::vector<int> nodal_adj_idx;
   //std::vector<int> nodal_adj_array;
+
+  std::vector<std::string> global_field_names;
+  std::vector<double> global_fields;
 
   std::vector<std::string> nodal_field_names;      
   std::vector<std::vector<double> > nodal_fields;

--- a/post_process/include/post_process.h
+++ b/post_process/include/post_process.h
@@ -63,7 +63,8 @@ public:
 	       SCALAR_OP s_op = NONE, ///< scalar operation to perform
 	       const int eqn_id = 0, ///< associate this post process variable with an equation
 	       const std::string basename = "pp", ///< basename this post process variable
-	       const double precision = 6 ///< precision for output file
+	       const double precision = 6, ///< precision for output file
+           const bool writedata = true
 	       );
   /// Destructor
   ~post_process();
@@ -129,6 +130,8 @@ private:
   int eqn_id_;
   /// Variable and file base name
   std::string basename_;
+  /// Write data bool
+  bool writedata_;
 
 
 

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -1831,7 +1831,9 @@ template<class scalar_type>
     write_exodus();
   }//if !dorestart
   else{
-    
+    const std::string ntsteps_name = "num_timesteps";
+    mesh_->add_global_field(ntsteps_name);
+
     restart(u_old_);//,u_old_old_);
     
 //     if(1==comm_->MyPID())
@@ -2850,6 +2852,12 @@ template<class scalar_type>
     }
   }
 
+  //grab the number of timesteps taken in the run before this restart
+  double ntsteps_d = -1;
+  error = mesh_->read_global_data_exodus(ex_id_, step, "num_timesteps", &ntsteps_d);
+  const int ntsteps = (int)ntsteps_d;
+  std::cout<<"read ntsteps "<<ntsteps<<std::endl;
+
   mesh_->close_exodus(ex_id_);
 
   //cn for now just put current values into old values, 
@@ -2879,14 +2887,18 @@ template<class scalar_type>
 
   step = step - 1;
   this->start_time = time;
-  int ntstep = (int)(time/dt_);
-  this->start_step = ntstep;
+  //start_step is not quite accurate here if adaptive
+  //int ntstep = (int)(time/dt_);
+  this->start_step = ntsteps;
+  this->cur_step = ntsteps;
   time_=time;
   output_step_ = step+2;
   //   u->Print(std::cout);
   //   exit(0);
   if( 0 == mypid ){
-    std::cout<<"Restarting at time = "<<time<<" and tusas step = "<<step<<std::endl<<std::endl;
+    std::cout<<"Restarting at time = "<<time
+             <<", time step = "<<ntsteps
+             <<", and output step = "<<step<<std::endl<<std::endl;
     std::cout<<"Exiting restart"<<std::endl<<std::endl;
   }
   //exit(0);

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -1757,7 +1757,9 @@ double ModelEvaluatorTPETRA<scalar_type>::advance()
     (*it)->estimate_gradient(u_old_);
     (*it)->estimate_error(u_old_);
   }
-  ++numsteps_;   
+  ++numsteps_;
+  this->cur_step++;
+  std::cout<<"advance cur_step "<<this->cur_step<<std::endl;
 
   dt_ = dtpred;
   return dtold_;
@@ -2613,13 +2615,9 @@ int ModelEvaluatorTPETRA<scalar_type>:: update_mesh_data()
 
   // just have one global variable for now, otherwise this
   // could be called in a loop as update_nodal_data above
-  // additionally, it would be better to track ntsteps within
-  // a given instance of a modal object, rather than doing
-  // output_freq * output_step_
-  const int output_freq = paramList.get<int> (TusasoutputfreqNameString);
-  const int ntsteps = output_freq * (output_step_ - 1);
+  const int ntsteps = this->cur_step;
   mesh_->update_global_data("num_timesteps", (double)ntsteps);
-  std::cout<<"ntsteps "<<ntsteps<<std::endl;
+  std::cout<<"this->cur_step "<<this->cur_step<<std::endl;
 
   std::vector<error_estimator*>::iterator it;
   for(it = Error_est.begin();it != Error_est.end();++it){

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -1816,6 +1816,11 @@ template<class scalar_type>
       mesh_->add_nodal_field((*varnames_)[k]);
     }
 
+    //create a global variable to store the number of
+    //time-steps elapsed
+    const std::string ntsteps_name = "num_timesteps";
+    mesh_->add_global_field(ntsteps_name);
+
     if(paramList.get<bool> (TusasestimateTimestepNameString)){    
       setadaptivetimestep();
     }

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -3275,7 +3275,8 @@ void ModelEvaluatorTPETRA<Scalar>::setadaptivetimestep()
 						post_process::NORMRMS, 
 						k, 
 						"temperror",
-						16));
+						16,
+                        false));
 	//be with an error estimate based on second derivative
 	if(atsList->get<std::string> (TusasatstypeNameString) == "second derivative")
 	   temporal_est[k]->postprocfunc_ = &timeadapt::d2udt2_;
@@ -3302,7 +3303,8 @@ void ModelEvaluatorTPETRA<Scalar>::setadaptivetimestep()
 						 post_process::NORMRMS, 
 						 k, 
 						 "tempnorm",
-						 16));
+						 16,
+                         false));
  	temporal_norm[k]->postprocfunc_ = &timeadapt::normu_;
 
       }

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -2611,6 +2611,16 @@ int ModelEvaluatorTPETRA<scalar_type>:: update_mesh_data()
     mesh_->update_nodal_data((*varnames_)[k], &output[k][0]);
   }
 
+  // just have one global variable for now, otherwise this
+  // could be called in a loop as update_nodal_data above
+  // additionally, it would be better to track ntsteps within
+  // a given instance of a modal object, rather than doing
+  // output_freq * output_step_
+  const int output_freq = paramList.get<int> (TusasoutputfreqNameString);
+  const int ntsteps = output_freq * (output_step_ - 1);
+  mesh_->update_global_data("num_timesteps", (double)ntsteps);
+  std::cout<<"ntsteps "<<ntsteps<<std::endl;
+
   std::vector<error_estimator*>::iterator it;
   for(it = Error_est.begin();it != Error_est.end();++it){
     (*it)->update_mesh_data();

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -339,7 +339,7 @@ ModelEvaluatorTPETRA( const Teuchos::RCP<const Epetra_Comm>& comm,
   //there are some epetra_maps and a routine that does mpi calls for off proc comm const 
   //Comm = Teuchos::rcp(new Epetra_MpiComm( MPI_COMM_WORLD ));
   bool dorestart = paramList.get<bool> (TusasrestartNameString);
-  Elem_col = Teuchos::rcp(new elem_color(mesh,dorestart));
+  Elem_col = Teuchos::rcp(new elem_color(mesh,dorestart,false));
 
   if( paramList.get<bool>(TusasrandomDistributionNameString) ){
     const int LTP_quadrature_order = paramList.get<int> (TusasltpquadordNameString);

--- a/timestep/include/timestep.hpp
+++ b/timestep/include/timestep.hpp
@@ -20,7 +20,7 @@ class timestep
 
 public:
   /// Constructor
-  timestep():start_time(0.0),start_step(0){};
+  timestep():start_time(0.0),start_step(0),cur_step(0){};
   /// Destructor
   virtual ~timestep(){};
   /// Initialize
@@ -33,6 +33,8 @@ public:
   virtual void finalize() = 0;
   /// Write solution to exodusII file.
   virtual void write_exodus() = 0;
+  /// Return the current number of timesteps taken.
+  virtual int get_cur_step(){return cur_step;};
   /// Return the timestep index for restart.
   virtual int get_start_step(){return start_step;};
   /// Return the timestep for restart.
@@ -44,6 +46,8 @@ public:
   double start_time;
   /// Timestep index for restart.
   int start_step;
+  /// Count of total number of timesteps taken.
+  int cur_step;
   
 };
 


### PR DESCRIPTION
This PR ports commits from master that allow for:
- tracking number of time steps taken across restarts via a global exodus variable
- bools to disable write of temp variables and element coloring to exodus