### PR TITLE
Test case definition refactor

### DIFF
--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -2997,12 +2997,12 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     (*residualfunc_)[1] = cases::tonks1::residual_eta_dp;
 
     preconfunc_ = new std::vector<PREFUNC>(numeqs_);
-    (*preconfunc_)[0] = &cases::tonks1::prec_c_;
-    (*preconfunc_)[1] = &cases::tonks1::prec_eta_;
+    (*preconfunc_)[0] = &cases::tonks1::prec_c;
+    (*preconfunc_)[1] = &cases::tonks1::prec_eta;
 
     initfunc_ = new std::vector<INITFUNC>(numeqs_);
-    (*initfunc_)[0] = &cases::tonks1::init_c_;
-    (*initfunc_)[1] = &cases::tonks1::init_eta_;
+    (*initfunc_)[0] = &cases::tonks1::init_c;
+    (*initfunc_)[1] = &cases::tonks1::init_eta;
 
     varnames_ = new std::vector<std::string>(numeqs_);
     (*varnames_)[0] = "c";
@@ -3012,11 +3012,11 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     neumannfunc_ = NULL;
 
     paramfunc_.resize(2);
-    paramfunc_[0] = &tools::solvers::param_;
-    paramfunc_[1] = &cases::tonks1::param_;
+    paramfunc_[0] = &tools::solvers::param;
+    paramfunc_[1] = &cases::tonks1::param;
 
-    post_proc.push_back(new post_process(mesh_,(int)0));
-    post_proc[0].postprocfunc_ = &tpetra::tonks::postproc_mu_a_;
+    //post_proc.push_back(new post_process(mesh_,(int)0));
+    //post_proc[0].postprocfunc_ = &tpetra::tonks::postproc_mu_a_;
     //post_proc.push_back(new post_process(mesh_,(int)1));
     //post_proc[1].postprocfunc_ = &tpetra::tonks::postproc_mu_b_;
     //post_proc.push_back(new post_process(mesh_,(int)2));

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -3013,7 +3013,7 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
 
     paramfunc_.resize(2);
     paramfunc_[0] = &tools::solvers::param;
-    paramfunc_[1] = &cases::tonks1::param;
+    paramfunc_[1] = &pdes::kks::param;
 
     //post_proc.push_back(new post_process(mesh_,(int)0));
     //post_proc[0].postprocfunc_ = &tpetra::tonks::postproc_mu_a_;

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -3011,9 +3011,8 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     dirichletfunc_ = NULL;
     neumannfunc_ = NULL;
 
-    paramfunc_.resize(2);
-    paramfunc_[0] = &tools::solvers::param;
-    paramfunc_[1] = &pdes::kks::param;
+    paramfunc_.resize(1);
+    paramfunc_[0] = &cases::tonks1::param;
 
     //post_proc.push_back(new post_process(mesh_,(int)0));
     //post_proc[0].postprocfunc_ = &tpetra::tonks::postproc_mu_a_;

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -1459,6 +1459,7 @@ void ModelEvaluatorTPETRA<scalar_type>::init_nox()
     scaling_ = Teuchos::null;
   }
 
+  // CHANGE THIS!!
   Thyra::V_S(initial_guess.ptr(),Teuchos::ScalarTraits<double>::one());
 
   // Create the JFNK operator
@@ -3125,7 +3126,7 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     paramfunc_.resize(1);
     paramfunc_[0] = &tpetra::sheng::param_;
 
-  }else if("shengsplitkks" == paramList.get<std::string> (TusastestNameString)){
+  }else if("shengsplitkksold" == paramList.get<std::string> (TusastestNameString)){
 
     Teuchos::ParameterList *problemList;
     problemList = &paramList.sublist("ProblemParams", false);
@@ -3160,6 +3161,41 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     paramfunc_[0] = &tpetra::sheng::param_split_offset_;
     paramfunc_[1] = &tpetra::kks::param_;
     paramfunc_[2] = &tpetra::sheng::param_;
+
+  }else if("shengsplitkks" == paramList.get<std::string> (TusastestNameString)){
+
+    Teuchos::ParameterList *problemList;
+    problemList = &paramList.sublist("ProblemParams", false);
+
+    const int numeta = 1;
+    numeqs_ = numeta + 2;
+
+    residualfunc_ = new std::vector<RESFUNC>(numeqs_);
+    (*residualfunc_)[0] = cases::sheng::residual_c_split_dp;
+    (*residualfunc_)[1] = cases::sheng::residual_mu_dp;
+    (*residualfunc_)[2] = cases::sheng::residual_eta_dp;
+
+    preconfunc_ = new std::vector<PREFUNC>(numeqs_);
+    (*preconfunc_)[0] = &cases::sheng::prec_c;
+    (*preconfunc_)[1] = &cases::sheng::prec_c;
+    (*preconfunc_)[2] = &cases::sheng::prec_eta;
+
+    initfunc_ = new std::vector<INITFUNC>(numeqs_);
+    (*initfunc_)[0] = &cases::sheng::init_c;
+    (*initfunc_)[1] = &cases::sheng::init_mu;
+    (*initfunc_)[2] = &cases::sheng::init_eta;
+
+    varnames_ = new std::vector<std::string>(numeqs_);
+    (*varnames_)[0] = "c";
+    (*varnames_)[1] = "mu";
+    (*varnames_)[2] = "eta";
+
+    dirichletfunc_ = NULL;
+    neumannfunc_ = NULL;
+
+    paramfunc_.resize(2);
+    paramfunc_[0] = &cases::sheng::param_split;
+    paramfunc_[1] = &cases::sheng::param;
 
   }else if("cahnhilliard" == paramList.get<std::string> (TusastestNameString)){
     //std::cout<<"cahnhilliard"<<std::endl;

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -3014,15 +3014,6 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     paramfunc_.resize(1);
     paramfunc_[0] = &cases::tonks1::param;
 
-    //post_proc.push_back(new post_process(mesh_,(int)0));
-    //post_proc[0].postprocfunc_ = &tpetra::tonks::postproc_mu_a_;
-    //post_proc.push_back(new post_process(mesh_,(int)1));
-    //post_proc[1].postprocfunc_ = &tpetra::tonks::postproc_mu_b_;
-    //post_proc.push_back(new post_process(mesh_,(int)2));
-    //post_proc[2].postprocfunc_ = &tpetra::tonks::postproc_ca_;
-    //post_proc.push_back(new post_process(mesh_,(int)3));
-    //post_proc[3].postprocfunc_ = &tpetra::tonks::postproc_cb_;
-    
   }else if("tonks1splitkks" == paramList.get<std::string> (TusastestNameString)){
 
     Teuchos::ParameterList *problemList;
@@ -3032,19 +3023,19 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     numeqs_ = numeta + 2;
 
     residualfunc_ = new std::vector<RESFUNC>(numeqs_);
-    (*residualfunc_)[0] = tpetra::tonks::residual_c_split_kks_dp_;
-    (*residualfunc_)[1] = tpetra::tonks::residual_mu_kks_dp_;
-    (*residualfunc_)[2] = tpetra::tonks::residual_eta_kks_dp_;
+    (*residualfunc_)[0] = cases::tonks1::residual_c_split_dp;
+    (*residualfunc_)[1] = cases::tonks1::residual_mu_dp;
+    (*residualfunc_)[2] = cases::tonks1::residual_eta_dp;
 
     preconfunc_ = new std::vector<PREFUNC>(numeqs_);
-    (*preconfunc_)[0] = &tpetra::tonks::prec_c_;
-    (*preconfunc_)[1] = &tpetra::tonks::prec_c_;
-    (*preconfunc_)[2] = &tpetra::tonks::prec_eta_;
+    (*preconfunc_)[0] = &cases::tonks1::prec_c;
+    (*preconfunc_)[1] = &cases::tonks1::prec_c;
+    (*preconfunc_)[2] = &cases::tonks1::prec_eta;
 
     initfunc_ = new std::vector<INITFUNC>(numeqs_);
-    (*initfunc_)[0] = &tpetra::tonks::init_c_;
-    (*initfunc_)[1] = &tpetra::tonks::init_mu_;
-    (*initfunc_)[2] = &tpetra::tonks::init_eta_;
+    (*initfunc_)[0] = &cases::tonks1::init_c;
+    (*initfunc_)[1] = &cases::tonks1::init_mu;
+    (*initfunc_)[2] = &cases::tonks1::init_eta;
 
     varnames_ = new std::vector<std::string>(numeqs_);
     (*varnames_)[0] = "c";
@@ -3054,19 +3045,9 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     dirichletfunc_ = NULL;
     neumannfunc_ = NULL;
 
-    paramfunc_.resize(3);
-    paramfunc_[0] = &tpetra::tonks::param_split_offset_;
-    paramfunc_[1] = &tpetra::kks::param_;
-    paramfunc_[2] = &tpetra::tonks::param_;
-
-    post_proc.push_back(new post_process(mesh_,(int)0));
-    post_proc[0].postprocfunc_ = &tpetra::tonks::postproc_mu_a_;
-    //post_proc.push_back(new post_process(mesh_,(int)1));
-    //post_proc[1].postprocfunc_ = &tpetra::tonks::postproc_mu_b_;
-    //post_proc.push_back(new post_process(mesh_,(int)2));
-    //post_proc[2].postprocfunc_ = &tpetra::tonks::postproc_ca_;
-    //post_proc.push_back(new post_process(mesh_,(int)3));
-    //post_proc[3].postprocfunc_ = &tpetra::tonks::postproc_cb_;
+    paramfunc_.resize(2);
+    paramfunc_[0] = &cases::tonks1::param_split;
+    paramfunc_[1] = &cases::tonks1::param;
     
   }else if("tonks2splitkks" == paramList.get<std::string> (TusastestNameString)){
 

--- a/timestep/include/ModelEvaluatorTPETRA_def.hpp
+++ b/timestep/include/ModelEvaluatorTPETRA_def.hpp
@@ -54,6 +54,7 @@
 //#include <string>
 
 #include "function_def.hpp"
+#include "cases.hpp"
 #include "ParamNames.h"
 #include "greedy_tie_break.hpp"
 
@@ -2992,16 +2993,16 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     numeqs_ = numeta + 1;
 
     residualfunc_ = new std::vector<RESFUNC>(numeqs_);
-    (*residualfunc_)[0] = tpetra::tonks::residual_c_kks_new_dp_;
-    (*residualfunc_)[1] = tpetra::tonks::residual_eta_kks_dp_;
+    (*residualfunc_)[0] = cases::tonks1::residual_c_dp;
+    (*residualfunc_)[1] = cases::tonks1::residual_eta_dp;
 
     preconfunc_ = new std::vector<PREFUNC>(numeqs_);
-    (*preconfunc_)[0] = &tpetra::tonks::prec_c_;
-    (*preconfunc_)[1] = &tpetra::tonks::prec_eta_;
+    (*preconfunc_)[0] = &cases::tonks1::prec_c_;
+    (*preconfunc_)[1] = &cases::tonks1::prec_eta_;
 
     initfunc_ = new std::vector<INITFUNC>(numeqs_);
-    (*initfunc_)[0] = &tpetra::tonks::init_c_;
-    (*initfunc_)[1] = &tpetra::tonks::init_eta_;
+    (*initfunc_)[0] = &cases::tonks1::init_c_;
+    (*initfunc_)[1] = &cases::tonks1::init_eta_;
 
     varnames_ = new std::vector<std::string>(numeqs_);
     (*varnames_)[0] = "c";
@@ -3011,8 +3012,8 @@ void ModelEvaluatorTPETRA<scalar_type>::set_test_case()
     neumannfunc_ = NULL;
 
     paramfunc_.resize(2);
-    paramfunc_[0] = &tpetra::kks::param_;
-    paramfunc_[1] = &tpetra::tonks::param_;
+    paramfunc_[0] = &tools::solvers::param_;
+    paramfunc_[1] = &cases::tonks1::param_;
 
     post_proc.push_back(new post_process(mesh_,(int)0));
     post_proc[0].postprocfunc_ = &tpetra::tonks::postproc_mu_a_;

--- a/timestep/include/cases.hpp
+++ b/timestep/include/cases.hpp
@@ -29,6 +29,15 @@ namespace tonks1
     pdes::kks::param(plist);
   }
 
+  PARAM_FUNC(param_split)
+  {
+    // might be worth trying to think of a way for the user
+    // to pass these values in from ModelEvaluator...
+    pdes::kks::eta_start_idx = 2;
+    pdes::kks::c_start_idx = 0;
+    pdes::kks::mu_start_idx = 1;
+  }
+
   KOKKOS_INLINE_FUNCTION
   const double mobility(const double hh) {
     return pdes::kks::M * (1. - hh) + hh;
@@ -52,6 +61,30 @@ namespace tonks1
     return pdes::parabolicenergy::c1 * hh + pdes::parabolicenergy::c2 * (1. - hh);
   }
 
+  INI_FUNC(init_mu)
+  {
+    const int Neta_max = pdes::kks::Neta_max;
+    const int Neta = pdes::kks::Neta;
+    const int eta_start_idx = pdes::kks::eta_start_idx;
+
+    double eta[Neta_max];
+    for (int k = 0; k < Neta; ++k) {
+      eta[k] = init_eta(x, y, z, k + eta_start_idx, lid);
+    }
+    const double hh = pdes::parabolicenergy::h(eta);
+    const double c = init_c(x, y, z, eqn_id, lid);
+
+    double ca = pdes::parabolicenergy::c1;
+    double cb = pdes::parabolicenergy::c2;
+    tools::solvers::solve_kks(c, hh, ca, cb,
+                              pdes::parabolicenergy::dfa_dca,
+                              pdes::parabolicenergy::dfb_dcb,
+                              pdes::parabolicenergy::d2fa_dca2,
+                              pdes::parabolicenergy::d2fb_dcb2);
+    // based off eq (28) in the original KKS paper
+    return pdes::parabolicenergy::dfa_dca(ca);
+  }
+
   KOKKOS_INLINE_FUNCTION
   RES_FUNC_TPETRA(residual_eta)
   {
@@ -69,6 +102,24 @@ namespace tonks1
                             vol, rand, mobility);
   }
   TUSAS_DEVICE RES_FUNC_TPETRA((*residual_c_dp)) = residual_c;
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_c_split)
+  {
+    return pdes::kks::pde_c_split(basis, i, dt_, dtold_,
+                                  t_theta_, t_theta2_, time, eqn_id,
+                                  vol, rand, mobility);
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_c_split_dp)) = residual_c_split;
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_mu)
+  {
+    return pdes::kks::pde_mu(basis, i, dt_, dtold_,
+                             t_theta_, t_theta2_, time, eqn_id,
+                             vol, rand);
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_mu_dp)) = residual_mu;
 
   KOKKOS_INLINE_FUNCTION
   PRE_FUNC_TPETRA(prec_eta)

--- a/timestep/include/cases.hpp
+++ b/timestep/include/cases.hpp
@@ -136,6 +136,147 @@ namespace tonks1
 
 }  // namespace tonks1
 
+
+namespace sheng
+{
+
+  
+  TUSAS_DEVICE const double initial_c_alpha = 0.05;
+  TUSAS_DEVICE double r = 5e-6;  // cm
+  TUSAS_DEVICE double d = 5e-6;  // cm
+  TUSAS_DEVICE double S = 0.05;
+  TUSAS_DEVICE double D = 0.019 * std::exp(-5840. / 673.);  // cm^2/s
+
+
+  PARAM_FUNC(param)
+  {
+    r = plist->get<double>("r", r);
+    d = plist->get<double>("d", d);
+    S = plist->get<double>("S", S);
+    D = plist->get<double>("D", D);
+
+    // set base PDE params
+    pdes::kks::param(plist);
+    
+    const int x0 = pdes::kks::x0;
+    const int f0 = pdes::kks::f0;
+    const int t0 = pdes::kks::t0;
+    
+    r /= x0;
+    d /= x0;
+    S *= t0;
+    D = D * t0 * f0 / x0 / x0;
+  }
+
+  PARAM_FUNC(param_split)
+  {
+    // might be worth trying to think of a way for the user
+    // to pass these values in from ModelEvaluator...
+    pdes::kks::eta_start_idx = 2;
+    pdes::kks::c_start_idx = 0;
+    pdes::kks::mu_start_idx = 1;
+  }
+
+  
+  INI_FUNC(init_eta)
+  {
+    const double sqrtw = std::sqrt(pdes::kks::w);
+    const double rr = std::sqrt(x * x + y * y + z * z);
+    
+    // this is l = xi * sqrt(2 * k_eta_) / sqrtw with xi = 1 instead of 4
+    const double xi = 1.;
+    const double lambda = xi * std::sqrt(2 * pdes::kks::k_eta) / sqrtw;
+    return 0.5 * (1. - tanh((rr - r) / lambda));
+  }
+
+  INI_FUNC(init_c)
+  {
+    const double eta = init_eta(x, y, z, eqn_id, lid);
+    const double hh = pdes::parabolicenergy::h(&eta);
+    return pdes::parabolicenergy::c1 * hh + initial_c_alpha * (1. - hh);
+  }
+
+  INI_FUNC(init_mu)
+  {
+    const int Neta_max = pdes::kks::Neta_max;
+    const int Neta = pdes::kks::Neta;
+    const int eta_start_idx = pdes::kks::eta_start_idx;
+
+    double eta[Neta_max];
+    for (int k = 0; k < Neta; ++k) {
+      eta[k] = init_eta(x, y, z, k + eta_start_idx, lid);
+    }
+    const double hh = pdes::parabolicenergy::h(eta);
+    const double c = init_c(x, y, z, eqn_id, lid);
+
+    double ca = pdes::parabolicenergy::c1;
+    double cb = pdes::parabolicenergy::c2;
+    tools::solvers::solve_kks(c, hh, ca, cb,
+                              pdes::parabolicenergy::dfa_dca,
+                              pdes::parabolicenergy::dfb_dcb,
+                              pdes::parabolicenergy::d2fa_dca2,
+                              pdes::parabolicenergy::d2fb_dcb2);
+    // based off eq (28) in the original KKS paper
+    return pdes::parabolicenergy::dfa_dca(ca);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double mobility(const double hh) {
+    // M = D * d2f_dc2
+    return D * pdes::parabolicenergy::d2fa_dca2() * pdes::parabolicenergy::d2fb_dcb2() 
+             / ((1 - hh) * pdes::parabolicenergy::d2fa_dca2() + hh * pdes::parabolicenergy::d2fb_dcb2());
+  }
+  
+  KOKKOS_INLINE_FUNCTION 
+  const double S_forcing(const double y){
+    return (y < d) ? S : 0;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_eta)
+  {
+    return pdes::kks::pde_eta(basis, i, dt_, dtold_,
+                              t_theta_, t_theta2_, time, eqn_id,
+                              vol, rand, mobility);
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_eta_dp)) = residual_eta;
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_c_split)
+  {
+    const double y = -(basis[0]->yy());
+    const double s = S_forcing(y) * basis[0]->phi(i);
+    
+    return pdes::kks::pde_c_split(basis, i, dt_, dtold_,
+                                  t_theta_, t_theta2_, time, eqn_id,
+                                  vol, rand, mobility) - s;
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_c_split_dp)) = residual_c_split;
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_mu)
+  {
+    return pdes::kks::pde_mu(basis, i, dt_, dtold_,
+                             t_theta_, t_theta2_, time, eqn_id,
+                             vol, rand);
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_mu_dp)) = residual_mu;
+
+  KOKKOS_INLINE_FUNCTION
+  PRE_FUNC_TPETRA(prec_eta)
+  {
+    return pdes::kks::prec_eta(basis, i, j, dt_, t_theta_, eqn_id);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  PRE_FUNC_TPETRA(prec_c)
+  {
+    return pdes::kks::prec_c(basis, i, j, dt_, t_theta_, eqn_id, mobility);
+  }
+
+
+}  // namespace sheng
+
     
 }  // namespace cases
 

--- a/timestep/include/cases.hpp
+++ b/timestep/include/cases.hpp
@@ -12,7 +12,6 @@
 
 
 #include "pdes.hpp"
-#include "tools.hpp"
 
 
 namespace cases
@@ -22,6 +21,13 @@ namespace cases
 namespace tonks1
 {
 
+
+  PARAM_FUNC(param)
+  {
+    // if we wanted to set default values for all the 
+    // parameters in pdes::kks, we could set them manually here?
+    pdes::kks::param(plist);
+  }
 
   KOKKOS_INLINE_FUNCTION
   const double mobility(const double hh) {

--- a/timestep/include/cases.hpp
+++ b/timestep/include/cases.hpp
@@ -19,504 +19,20 @@ namespace cases
 {
 
 
-namespace parabolicenergy
-{
-  /*
-   *
-   * This namespace implements parabolic free energy
-   * density functions, their derivatives, and related
-   * functions
-   *
-   * As in the kks namespace, this implementation assumes
-   * two phases, an a-phase ("solid") and a b-phase ("liquid"):
-   *   a corresponds to eta
-   *   b corresponds to 1 - eta
-   *
-   * The free energy density functions are
-   *   fa(ca) = Aa_ * (ca - (c1_ + delta_c1_))^2 + f1_
-   *   fb(cb) = Ab_ * (cb - (c2_ + delta_c2_))^2 + f2_
-   *
-   * We also supply overloaded versions of relevant functions
-   * where we assume that ca = cb = c for non-kks solves
-   *
-   */
-  TUSAS_DEVICE double Aa = 2.;
-  TUSAS_DEVICE double Ab = 2.;
-  TUSAS_DEVICE double c1 = 0.3;
-  TUSAS_DEVICE double c2 = 0.7;
-  TUSAS_DEVICE double delta_c1 = 0.;
-  TUSAS_DEVICE double delta_c2 = 0.;
-  TUSAS_DEVICE double f1 = 0.;
-  TUSAS_DEVICE double f2 = 0.;
-  TUSAS_DEVICE const double alpha = 5.;  // pfhub2 coef in g
-  
-  TUSAS_DEVICE const int Neta_max = 4;
-  TUSAS_DEVICE int Neta = 1;
-
-  PARAM_FUNC(param)
-  {
-    int Np = plist->get<int>("N_ETA", Neta);
-#ifdef TUSAS_HAVE_CUDA
-    cudaMemcpyToSymbol(Neta, &Np, sizeof(int));
-#else
-    Neta = Np;
-#endif
-    if(Neta > Neta_max) exit(0);
-
-    // parameters from Sheng 2022, eqns 8, 9
-    Aa = plist->get<double>("Aa", Aa);
-    Ab = plist->get<double>("Ab", Ab);
-    c1 = plist->get<double>("c1", c1);
-    c2 = plist->get<double>("c2", c2);
-    delta_c1 = plist->get<double>("delta_c1", delta_c1);
-    delta_c2 = plist->get<double>("delta_c2", delta_c2);
-    f1 = plist->get<double>("f1", f1);
-    f2 = plist->get<double>("f2", f2);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  const double fa(const double ca)
-  {
-    // f_alpha(c_alpha) from Sheng 2022, eqn 8
-    // altered to be more general as eqn 9
-    return Aa * (ca - (c1 + delta_c1))
-              * (ca - (c1 + delta_c1)) + f1;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  const double fb(const double cb)
-  {
-    // f_beta(c_beta) from Sheng 2022, eqn 9
-    return Ab * (cb - (c2 + delta_c2))
-              * (cb - (c2 + delta_c2)) + f2;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  const double dfa_dca(const double ca)
-  {
-    return 2 * Aa * (ca - (c1 + delta_c1));
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  const double dfb_dcb(const double cb)
-  {
-    return 2 * Ab * (cb - (c2 + delta_c2));
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  const double d2fa_dca2()
-  {
-    return 2 * Aa;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  const double d2fb_dcb2()
-  {
-    return 2 * Ab;
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  const double h(const double *eta)
-  {
-    double val = 0.;
-    for (int i = 0; i < Neta; i++) {
-      val += eta[i] * eta[i] * eta[i] 
-               * (6. * eta[i] * eta[i] - 15. * eta[i] + 10.);
-    }
-    return val;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  double dh_deta(const double eta)
-  {
-    return eta * eta * ((30. * eta - 60.) * eta + 30.);
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  const double dg_deta(const double *eta, const int eqn_id)
-  {
-    double aval = 0.;
-    for (int i = 0; i < Neta; i++) {
-      aval += eta[i] * eta[i];
-    }
-    aval = aval - eta[eqn_id]*eta[eqn_id];
-    return 2. * eta[eqn_id] * (1. - eta[eqn_id]) * (1. - eta[eqn_id])  
-             - 2. * eta[eqn_id] * eta[eqn_id] * (1. - eta[eqn_id])
-             + 4. * alpha * eta[eqn_id] * aval;
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  double f(const double c, const double *eta)
-  {
-    // assumes that ca and cb are the same quanitity 
-    const double hh = h(eta);
-    return fa(c) * hh + fb(c) * (1. - hh);
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  double f(const double ca, const double cb, const double *eta)
-  {
-    const double hh = h(eta);
-    return fa(ca) * hh + fb(cb) * (1. - hh);
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  double df_dc(const double c, const double *eta)
-  {
-    // assumes that ca and cb are the same quanitity
-    const double hh = h(eta);
-    return dfa_dca(c) * hh + dfb_dcb(c) * (1. - hh);
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  double df_dc(const double ca, const double cb, const double *eta)
-  {
-    // TODO: remove this function
-    // assumes that dca/dc = dcb/dc = 1, which is not true
-    // probably best to never use this function and use 
-    // eq 28 from KKS instead -- leaving it here for now
-    const double hh = h(eta);
-    return dfa_dca(ca) * hh + dfb_dcb(cb) * (1. - hh);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  double d2f_dc2(const double *eta)
-  {
-    // assumes that ca and cb are the same quanitity
-    const double hh = h(eta);
-    return d2fa_dca2() * hh + d2fb_dcb2() * (1. - hh);
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  const double df_deta(const double c, const double eta)
-  {
-    // assumes that ca and cb are the same quanitity
-    // and does **not** include the w g' term
-
-    // dh(eta1, eta2) / deta1 is a function of eta1 only
-    const double dhdeta = dh_deta(eta);
-    return fa(c) * dhdeta + fb(c) * (-dhdeta);
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  const double df_deta(const double ca, const double cb, const double eta)
-  {
-    // does not include the w g' term
-
-    // dh(eta1, eta2) / deta1 is a function of eta1 only
-    const double dhdeta = dh_deta(eta);
-    return fa(ca) * dhdeta + fb(cb) * (-dhdeta)
-             + dhdeta * dfb_dcb(cb) * (cb - ca);
-  }
-
-
-}  // namespace parabolicenergy
-
-
 namespace tonks1
 {
- 
-  TUSAS_DEVICE const int Nt_max = 3;
-  
-  TUSAS_DEVICE const int Nc_max = 2;
-  TUSAS_DEVICE int Nc = 1;
-  TUSAS_DEVICE int c_start_idx = 0;
 
-  TUSAS_DEVICE const int Nmu_max = 2;
-  TUSAS_DEVICE int Nmu = 1;
-  TUSAS_DEVICE int mu_start_idx = 1;
-
-  TUSAS_DEVICE const int Neta_max = 4;
-  TUSAS_DEVICE int Neta = 1;
-  TUSAS_DEVICE int eta_start_idx = 1;
-  
-  TUSAS_DEVICE double t0 = 1.;
-  TUSAS_DEVICE double x0 = 1.;
-  TUSAS_DEVICE double f0 = 1.;
-  TUSAS_DEVICE double k_c = 0.;
-  TUSAS_DEVICE double k_eta = 1.5;
-  TUSAS_DEVICE double M = 10.;
-  TUSAS_DEVICE double L = 2.;
-  TUSAS_DEVICE double w = 12.;
-
-  PARAM_FUNC(param)
-  {
-    int Np = plist->get<int>("N_ETA", Neta);
-#ifdef TUSAS_HAVE_CUDA
-    cudaMemcpyToSymbol(Neta, &Np, sizeof(int));
-#else
-    Neta = Np;
-#endif
-    if(Neta > Neta_max) exit(0);
-
-    // nondim free energy density, J/m^3
-    // generally, should be ~parabolicenergy::Aa_
-    f0 = plist->get<double>("f0", f0);
-    // nondim spatial scaling, m
-    x0 = plist->get<double>("x0", x0);
-    // nondim temporal scaling, s
-    t0 = plist->get<double>("t0", t0);
-
-    k_c = plist->get<double>("k_c", k_c);
-    k_eta = plist->get<double>("k_eta", k_eta);
-    M = plist->get<double>("M", M);
-    L = plist->get<double>("L", L);
-    w = plist->get<double>("w", w);
-
-    // set params for free energy density
-    parabolicenergy::param(plist);
-
-    // nondimensionalize
-    // note that if x0_, t0_, and f0_ are not
-    // set by the user in an input file, these
-    // values default to 1 and the original
-    // dimensional equations are preserved
-    parabolicenergy::Aa = parabolicenergy::Aa / f0;
-    parabolicenergy::Ab = parabolicenergy::Ab / f0;
-    parabolicenergy::f1 = parabolicenergy::f1 / f0;
-    parabolicenergy::f2 = parabolicenergy::f2 / f0;
-    k_c = k_c / x0 / x0 / f0;
-    k_eta = k_eta / x0 / x0 / f0;
-    M = M * t0 * f0 / x0 / x0;
-    L = L * t0 * f0;
-    w = w / f0;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const double mobility(const double hh) {
-    return M * (1. - hh) + hh;
+    return pdes::kks::M * (1. - hh) + hh;
   } 
-
-  KOKKOS_INLINE_FUNCTION 
-  RES_FUNC_TPETRA(residual_eta)
-  {
-    const int Nt = 3;
-
-    const int local_id = eqn_id - eta_start_idx;
-
-    const double phi = basis[0]->phi(i);
-    const double dphi_dx = basis[0]->dphidx(i);
-    const double dphi_dy = basis[0]->dphidy(i);
-    const double dphi_dz = basis[0]->dphidz(i);
-
-    double c[Nt_max * Nc_max];
-    double dc_dx[Nt_max * Nc_max];
-    double dc_dy[Nt_max * Nc_max];
-    double dc_dz[Nt_max * Nc_max];
-    tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
-    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
-
-    double eta[Nt_max * Neta_max];
-    double deta_dx[Nt_max * Neta_max];
-    double deta_dy[Nt_max * Neta_max];
-    double deta_dz[Nt_max * Neta_max];
-    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
-    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
-
-    double hh[Nt_max];
-    double ca[Nt_max];
-    double cb[Nt_max];
-    double k_divgrad_eta[Nt_max];
-    double df_deta[Nt_max];
-    double f[Nt_max];
-
-    int idx = 0;
-    for (int tdx = 0; tdx < Nt; ++tdx) {
-      hh[tdx] = parabolicenergy::h(&eta[tdx * Neta_max]);
-      
-      ca[tdx] = parabolicenergy::c1;
-      cb[tdx] = parabolicenergy::c2;
-      idx = tools::utils::idx(tdx, local_id, Nc_max);
-      tools::solvers::solve_kks(c[idx], hh[tdx], ca[tdx], cb[tdx],
-                                parabolicenergy::dfa_dca,
-                                parabolicenergy::dfb_dcb,
-                                parabolicenergy::d2fa_dca2,
-                                parabolicenergy::d2fb_dcb2);
-
-      idx = tools::utils::idx(tdx, local_id, Neta_max);
-      df_deta[tdx] = (parabolicenergy::df_deta(ca[tdx], cb[tdx], eta[idx])
-                        + w * parabolicenergy::dg_deta(&eta[tdx * Neta_max], local_id)) * phi;
-      k_divgrad_eta[tdx] = k_eta * (deta_dx[idx] * dphi_dx + deta_dy[idx] * dphi_dy + deta_dz[idx] * dphi_dz);
-
-      f[tdx] = L* (k_divgrad_eta[tdx] + df_deta[tdx]);
-    }
-
-    const double deta_dt = (eta[tools::utils::idx(0, local_id, Neta_max)] 
-                              - eta[tools::utils::idx(1, local_id, Neta_max)]) / dt_ * phi;
-
-    return tools::utils::ret_value(deta_dt, f, dt_, dtold_, t_theta_, t_theta2_);
-  }
-  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_eta_dp)) = residual_eta;
-
-  KOKKOS_INLINE_FUNCTION
-  RES_FUNC_TPETRA(residual_c)
-  {
-    // number of time levels to compute
-    // might want to pass this in to res func?
-    const int Nt = 3;
-
-    // test function
-    const double phi = basis[0]->phi(i);
-    // grad(phi)
-    const double dphi_dx = basis[0]->dphidx(i);
-    const double dphi_dy = basis[0]->dphidy(i);
-    const double dphi_dz = basis[0]->dphidz(i);
-
-    // populate c viewed as a "matrix"
-    //   c[time_idx, c_idx]
-    // but really a 1D array that
-    // we can index this using
-    //   utils::idx(time_idx, c_idx, Nc_max)
-    double c[Nt_max * Nc_max] = {0.};
-    double dc_dx[Nt_max * Nc_max] = {0.};
-    double dc_dy[Nt_max * Nc_max] = {0.};
-    double dc_dz[Nt_max * Nc_max] = {0.};
-    tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
-    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
-
-    // populate eta viewed as a "matrix"
-    //   eta[time_idx, eta_idx]
-    // but really a 1D array that
-    // we can index this using
-    //   utils::idx(time_idx, eta_idx, Neta_max)
-    double eta[Nt_max * Neta_max] = {0.};
-    double deta_dx[Nt_max * Neta_max] = {0.};
-    double deta_dy[Nt_max * Neta_max] = {0.};
-    double deta_dz[Nt_max * Neta_max] = {0.};
-    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
-    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
-
-    // define all the variables we need to calculate 
-    // the residual = Mdivgrad_df_dc
-    double hh[Nt_max] = {0.};
-    double dh_dx[Nt_max] = {0.};
-    double dh_dy[Nt_max] = {0.};
-    double dh_dz[Nt_max] = {0.};
-    double ca[Nt_max] = {0.};
-    double cb[Nt_max] = {0.};
-    double d2f_dc2[Nt_max] = {0.};
-    double d2f_dcdx[Nt_max] = {0.};
-    double d2f_dcdy[Nt_max] = {0.};
-    double d2f_dcdz[Nt_max] = {0.};
-    double Mdivgrad_df_dc[Nt_max] = {0.};
-
-
-    // loop over each time level that we need data at
-    int idx = 0;
-    double dh_deta = 0;
-    for (int tdx = 0; tdx < Nt; ++tdx) {
-      // calculate h
-      hh[tdx] = parabolicenergy::h(&eta[tdx * Neta_max]);
-
-      // calculate grad h
-      dh_dx[tdx] = 0.;
-      dh_dy[tdx] = 0.;
-      dh_dz[tdx] = 0.;
-      for (int k = 0; k < Neta ; ++k) {
-        idx = tools::utils::idx(tdx, k, Neta_max);
-        dh_deta = parabolicenergy::dh_deta(eta[idx]);
-
-        dh_dx[tdx] += dh_deta * deta_dx[idx];
-        dh_dy[tdx] += dh_deta * deta_dy[idx];
-        dh_dz[tdx] += dh_deta * deta_dz[idx];
-      }
-
-      // do the kks solve to get ca and cb
-      // for the current component c_{eqn_id}
-      ca[tdx] = parabolicenergy::c1;
-      cb[tdx] = parabolicenergy::c2;
-      tools::solvers::solve_kks(c[tools::utils::idx(tdx, eqn_id, Nc_max)],
-                                hh[tdx],
-                                ca[tdx],
-                                cb[tdx],
-                                parabolicenergy::dfa_dca,
-                                parabolicenergy::dfb_dcb,
-                                parabolicenergy::d2fa_dca2,
-                                parabolicenergy::d2fb_dcb2);
-
-      // calculate d2f_dc2 using KKS eq 29 
-      d2f_dc2[tdx] = parabolicenergy::d2fa_dca2() * parabolicenergy::d2fb_dcb2() 
-                       / ((1 - hh[tdx]) * parabolicenergy::d2fa_dca2() + hh[tdx] * parabolicenergy::d2fb_dcb2());
-
-      // calculating grad(f_c) based on KKS eq 33, assuming M = D / f_cc
-      // this also follows from eq 30 and the chain rule
-      //   grad(f_c) = f_cc * h' * (cb - ca) * grad(eta) + f_cc * grad(c) 
-      //             = f_cc * (cb - ca) * grad(h) + f_cc * grad(c) 
-      idx = tools::utils::idx(tdx, eqn_id, Nc_max);
-      d2f_dcdx[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dx[tdx] + d2f_dc2[tdx] * dc_dx[idx];
-      d2f_dcdy[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dy[tdx] + d2f_dc2[tdx] * dc_dy[idx];
-      d2f_dcdz[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dz[tdx] + d2f_dc2[tdx] * dc_dz[idx];
-
-      // finally, calculate M * div(grad(f_c))
-      Mdivgrad_df_dc[tdx] = mobility(hh[tdx]) * (d2f_dcdx[tdx] * dphi_dx
-                                                 + d2f_dcdy[tdx] * dphi_dy
-                                                 + d2f_dcdz[tdx] * dphi_dz);
-    }  // tdx = 0, < Nt loop
-
-    const double dc_dt = (c[tools::utils::idx(0, eqn_id, Nc_max)] 
-                            - c[tools::utils::idx(1, eqn_id, Nc_max)]) / dt_ * phi;
-
-    return tools::utils::ret_value(dc_dt, Mdivgrad_df_dc, dt_, dtold_, t_theta_, t_theta2_);
-  }
-  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_c_dp)) = residual_c;
-  
-  KOKKOS_INLINE_FUNCTION 
-  PRE_FUNC_TPETRA(prec_eta)
-  {
-    const double phi_i = basis[0]->phi(i);
-    const double phi_j = basis[0]->phi(j);
-
-    const double dphi_dx_i = basis[0]->dphidx(i);
-    const double dphi_dy_i = basis[0]->dphidy(i);
-    const double dphi_dz_i = basis[0]->dphidz(i);
-    const double dphi_dx_j = basis[0]->dphidx(j);
-    const double dphi_dy_j = basis[0]->dphidy(j);
-    const double dphi_dz_j = basis[0]->dphidz(j);
-
-    const double divgrad = L * k_eta * (dphi_dx_i * dphi_dx_j 
-                                        + dphi_dy_i * dphi_dy_j 
-                                        + dphi_dz_i * dphi_dz_j);
-    const double ut = phi_i * phi_j / dt_;
-
-    return ut + t_theta_ * divgrad;
-  }
-
-  KOKKOS_INLINE_FUNCTION 
-  PRE_FUNC_TPETRA(prec_c)
-  {
-    const double phi_i = basis[0]->phi(i);
-    const double phi_j = basis[0]->phi(j);
-
-    const double dphi_dx_i = basis[0]->dphidx(i);
-    const double dphi_dy_i = basis[0]->dphidy(i);
-    const double dphi_dz_i = basis[0]->dphidz(i);
-    const double dphi_dx_j = basis[0]->dphidx(j);
-    const double dphi_dy_j = basis[0]->dphidy(j);
-    const double dphi_dz_j = basis[0]->dphidz(j);
-    
-    double eta[Neta_max];
-    for(int k = 0; k < Neta; ++k){
-      eta[k] = basis[k + eta_start_idx]->uu();
-    }
-    
-    const double hh = parabolicenergy::h(eta);
-    // note that we can skip the kks solve here only
-    // because the free energy is parabolic -- the
-    // second derivatives are constant
-    const double d2f_dc2 = parabolicenergy::d2fa_dca2() * parabolicenergy::d2fb_dcb2() 
-                             / ((1 - hh) * parabolicenergy::d2fa_dca2() + hh * parabolicenergy::d2fb_dcb2());
-    const double Mdivgrad_c = mobility(hh) * d2f_dc2 * (dphi_dx_i * dphi_dx_j 
-                                                        + dphi_dy_i * dphi_dy_j 
-                                                        + dphi_dz_i * dphi_dz_j);
-    const double ut = phi_i * phi_j / dt_;
-
-    return ut + t_theta_ * Mdivgrad_c;
-  }
 
   INI_FUNC(init_eta)
   {
     const double sqrt2 = std::sqrt(2.);
-    const double sqrtw = std::sqrt(w);
+    const double sqrtw = std::sqrt(pdes::kks::w);
+    const double k_eta = pdes::kks::k_eta;
     
     // this is l = xi * sqrt(2 * k_eta_) / sqrtw with xi = 1 instead of 4
     const double l = std::sqrt(2 * k_eta) / sqrtw;
@@ -526,9 +42,40 @@ namespace tonks1
   INI_FUNC(init_c)
   {
     const double eta = init_eta(x, y, z, eqn_id, lid);
-    const double hh = parabolicenergy::h(&eta);
-    return parabolicenergy::c1 * hh + parabolicenergy::c2 * (1. - hh);
+    const double hh = pdes::parabolicenergy::h(&eta);
+    return pdes::parabolicenergy::c1 * hh + pdes::parabolicenergy::c2 * (1. - hh);
   }
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_eta)
+  {
+    return pdes::kks::pde_eta(basis, i, dt_, dtold_,
+                              t_theta_, t_theta2_, time, eqn_id,
+                              vol, rand, mobility);
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_eta_dp)) = residual_eta;
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_c)
+  {
+    return pdes::kks::pde_c(basis, i, dt_, dtold_,
+                            t_theta_, t_theta2_, time, eqn_id,
+                            vol, rand, mobility);
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_c_dp)) = residual_c;
+
+  KOKKOS_INLINE_FUNCTION
+  PRE_FUNC_TPETRA(prec_eta)
+  {
+    return pdes::kks::prec_eta(basis, i, j, dt_, t_theta_, eqn_id);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  PRE_FUNC_TPETRA(prec_c)
+  {
+    return pdes::kks::prec_c(basis, i, j, dt_, t_theta_, eqn_id, mobility);
+  }
+
 
 }  // namespace tonks1
 

--- a/timestep/include/cases.hpp
+++ b/timestep/include/cases.hpp
@@ -463,47 +463,64 @@ namespace tonks1
   KOKKOS_INLINE_FUNCTION 
   PRE_FUNC_TPETRA(prec_eta)
   {
-    const double ut = basis[0]->phi(j) / dt_ * basis[0]->phi(i);
-    const double divgrad = L * k_eta * (basis[0]->dphidx(j) * basis[0]->dphidx(i)
-                           + basis[0]->dphidy(j) * basis[0]->dphidy(i)
-                           + basis[0]->dphidz(j) * basis[0]->dphidz(i));
+    const double phi_i = basis[0]->phi(i);
+    const double phi_j = basis[0]->phi(j);
+
+    const double dphi_dx_i = basis[0]->dphidx(i);
+    const double dphi_dy_i = basis[0]->dphidy(i);
+    const double dphi_dz_i = basis[0]->dphidz(i);
+    const double dphi_dx_j = basis[0]->dphidx(j);
+    const double dphi_dy_j = basis[0]->dphidy(j);
+    const double dphi_dz_j = basis[0]->dphidz(j);
+
+    const double divgrad = L * k_eta * (dphi_dx_i * dphi_dx_j 
+                                        + dphi_dy_i * dphi_dy_j 
+                                        + dphi_dz_i * dphi_dz_j);
+    const double ut = phi_i * phi_j / dt_;
+
     return ut + t_theta_ * divgrad;
   }
 
   KOKKOS_INLINE_FUNCTION 
   PRE_FUNC_TPETRA(prec_c)
   {
-    const double test = basis[0]->phi(i);
-    const double u_t = test * basis[0]->phi(j) / dt_;
+    const double phi_i = basis[0]->phi(i);
+    const double phi_j = basis[0]->phi(j);
+
+    const double dphi_dx_i = basis[0]->dphidx(i);
+    const double dphi_dy_i = basis[0]->dphidy(i);
+    const double dphi_dz_i = basis[0]->dphidz(i);
+    const double dphi_dx_j = basis[0]->dphidx(j);
+    const double dphi_dy_j = basis[0]->dphidy(j);
+    const double dphi_dz_j = basis[0]->dphidz(j);
     
-    double eta_array[Neta_max];
-    for(int kk = 0; kk < Neta; kk++){
-      int kk_off = kk + 1;
-      eta_array[kk] = basis[kk_off]->uu();
+    double eta[Neta_max];
+    for(int k = 0; k < Neta; ++k){
+      eta[k] = basis[k + eta_start_idx]->uu();
     }
     
-    const double hh = parabolicenergy::h(eta_array);
+    const double hh = parabolicenergy::h(eta);
     // note that we can skip the kks solve here only
     // because the free energy is parabolic -- the
     // second derivatives are constant
     const double d2f_dc2 = parabolicenergy::d2fa_dca2() * parabolicenergy::d2fb_dcb2() 
                              / ((1 - hh) * parabolicenergy::d2fa_dca2() + hh * parabolicenergy::d2fb_dcb2());
-    const double divgradc = mobility(hh) * d2f_dc2 * (basis[0]->dphidx(j) * basis[0]->dphidx(i)
-                             + basis[0]->dphidy(j) * basis[0]->dphidy(i)
-                             + basis[0]->dphidz(j) * basis[0]->dphidz(i));
-    return u_t + t_theta_ * divgradc;
+    const double Mdivgrad_c = mobility(hh) * d2f_dc2 * (dphi_dx_i * dphi_dx_j 
+                                                        + dphi_dy_i * dphi_dy_j 
+                                                        + dphi_dz_i * dphi_dz_j);
+    const double ut = phi_i * phi_j / dt_;
+
+    return ut + t_theta_ * Mdivgrad_c;
   }
 
   INI_FUNC(init_eta)
   {
-    std::cout << "init eta" << std::endl;
     const double sqrt2 = std::sqrt(2.);
     const double sqrtw = std::sqrt(w);
     
     // this is l = xi * sqrt(2 * k_eta_) / sqrtw with xi = 1 instead of 4
     const double l = std::sqrt(2 * k_eta) / sqrtw;
     return 0.5 * (1. - tanh((x - 30.) / (l * sqrt2)));
-    //return x < 30 ? 1 : 0;
   }
 
   INI_FUNC(init_c)

--- a/timestep/include/cases.hpp
+++ b/timestep/include/cases.hpp
@@ -1,0 +1,599 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) Triad National Security, LLC.  This file is part of the
+//  Tusas code (LA-CC-17-001) and is subject to the revised BSD license terms
+//  in the LICENSE file found in the top-level directory of this distribution.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef CASES_HPP
+#define CASES_HPP
+
+
+#include "pdes.hpp"
+#include "tools.hpp"
+
+
+namespace cases
+{
+
+
+namespace parabolicenergy
+{
+  /*
+   *
+   * This namespace implements parabolic free energy
+   * density functions, their derivatives, and related
+   * functions
+   *
+   * As in the kks namespace, this implementation assumes
+   * two phases, an a-phase ("solid") and a b-phase ("liquid"):
+   *   a corresponds to eta
+   *   b corresponds to 1 - eta
+   *
+   * The free energy density functions are
+   *   fa(ca) = Aa_ * (ca - (c1_ + delta_c1_))^2 + f1_
+   *   fb(cb) = Ab_ * (cb - (c2_ + delta_c2_))^2 + f2_
+   *
+   * We also supply overloaded versions of relevant functions
+   * where we assume that ca = cb = c for non-kks solves
+   *
+   */
+  TUSAS_DEVICE double Aa_ = 2.;
+  TUSAS_DEVICE double Ab_ = 2.;
+  TUSAS_DEVICE double c1_ = 0.3;
+  TUSAS_DEVICE double c2_ = 0.7;
+  TUSAS_DEVICE double delta_c1_ = 0.;
+  TUSAS_DEVICE double delta_c2_ = 0.;
+  TUSAS_DEVICE double f1_ = 0.;
+  TUSAS_DEVICE double f2_ = 0.;
+  TUSAS_DEVICE const double alpha_ = 5.;  // pfhub2 coef in g
+  
+  TUSAS_DEVICE const int N_ETA_MAX = 4;
+  TUSAS_DEVICE int N_ETA_ = 1;
+
+  PARAM_FUNC(param_)
+  {
+    int N_p = plist->get<int>("N_ETA", N_ETA_);
+#ifdef TUSAS_HAVE_CUDA
+    cudaMemcpyToSymbol(N_ETA_, &N_p, sizeof(int));
+#else
+    N_ETA_ = N_p;
+#endif
+    if(N_ETA_ > N_ETA_MAX) exit(0);
+
+    // parameters from Sheng 2022, eqns 8, 9
+    Aa_ = plist->get<double>("Aa", Aa_);
+    Ab_ = plist->get<double>("Ab", Ab_);
+    c1_ = plist->get<double>("c1", c1_);
+    c2_ = plist->get<double>("c2", c2_);
+    delta_c1_ = plist->get<double>("delta_c1", delta_c1_);
+    delta_c2_ = plist->get<double>("delta_c2", delta_c2_);
+    f1_ = plist->get<double>("f1", f1_);
+    f2_ = plist->get<double>("f2", f2_);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double fa(const double ca)
+  {
+    // f_alpha(c_alpha) from Sheng 2022, eqn 8
+    // altered to be more general as eqn 9
+    return Aa_ * (ca - (c1_ + delta_c1_))
+               * (ca - (c1_ + delta_c1_)) + f1_;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double fb(const double cb)
+  {
+    // f_beta(c_beta) from Sheng 2022, eqn 9
+    return Ab_ * (cb - (c2_ + delta_c2_))
+               * (cb - (c2_ + delta_c2_)) + f2_;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double dfa_dca(const double ca)
+  {
+    return 2 * Aa_ * (ca - (c1_ + delta_c1_));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double dfb_dcb(const double cb)
+  {
+    return 2 * Ab_ * (cb - (c2_ + delta_c2_));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double d2fa_dca2()
+  {
+    return 2 * Aa_;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double d2fb_dcb2()
+  {
+    return 2 * Ab_;
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double h(const double *eta)
+  {
+    double val = 0.;
+    for (int i = 0; i < N_ETA_; i++) {
+      val += eta[i] * eta[i] * eta[i] 
+               * (6. * eta[i] * eta[i] - 15. * eta[i] + 10.);
+    }
+    return val;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  double dh_deta(const double eta)
+  {
+    return eta * eta * ((30. * eta - 60.) * eta + 30.);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double dg_deta(const double *eta, const int eqn_id)
+  {
+    double aval = 0.;
+    for (int i = 0; i < N_ETA_; i++) {
+      aval += eta[i] * eta[i];
+    }
+    aval = aval - eta[eqn_id]*eta[eqn_id];
+    return 2. * eta[eqn_id] * (1. - eta[eqn_id]) * (1. - eta[eqn_id])  
+             - 2. * eta[eqn_id] * eta[eqn_id] * (1. - eta[eqn_id])
+             + 4. * alpha_ * eta[eqn_id] * aval;
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double f(const double c, const double *eta)
+  {
+    // assumes that ca and cb are the same quanitity 
+    const double hh = h(eta);
+    return fa(c) * hh + fb(c) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double f(const double ca, const double cb, const double *eta)
+  {
+    const double hh = h(eta);
+    return fa(ca) * hh + fb(cb) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double df_dc(const double c, const double *eta)
+  {
+    // assumes that ca and cb are the same quanitity
+    const double hh = h(eta);
+    return dfa_dca(c) * hh + dfb_dcb(c) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double df_dc(const double ca, const double cb, const double *eta)
+  {
+    // TODO: remove this function
+    // assumes that dca/dc = dcb/dc = 1, which is not true
+    // probably best to never use this function and use 
+    // eq 28 from KKS instead -- leaving it here for now
+    const double hh = h(eta);
+    return dfa_dca(ca) * hh + dfb_dcb(cb) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  double d2f_dc2(const double *eta)
+  {
+    // assumes that ca and cb are the same quanitity
+    const double hh = h(eta);
+    return d2fa_dca2() * hh + d2fb_dcb2() * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double df_deta(const double c, const double eta)
+  {
+    // assumes that ca and cb are the same quanitity
+    // and does **not** include the w g' term
+
+    // dh(eta1, eta2) / deta1 is a function of eta1 only
+    const double dhdeta = dh_deta(eta);
+    return fa(c) * dhdeta + fb(c) * (-dhdeta);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double df_deta(const double ca, const double cb, const double eta)
+  {
+    // does not include the w g' term
+
+    // dh(eta1, eta2) / deta1 is a function of eta1 only
+    const double dhdeta = dh_deta(eta);
+    return fa(ca) * dhdeta + fb(cb) * (-dhdeta)
+             + dhdeta * dfb_dcb(cb) * (cb - ca);
+  }
+
+
+}  // namespace parabolicenergy
+
+
+namespace tonks1
+{
+ 
+  TUSAS_DEVICE const int Nt_MAX_ = 3;
+  
+  TUSAS_DEVICE const int N_C_MAX_ = 2;
+  TUSAS_DEVICE int N_C_ = 1;
+  TUSAS_DEVICE int c_start_idx_ = 0;
+
+  TUSAS_DEVICE const int N_MU_MAX_ = 2;
+  TUSAS_DEVICE int N_MU_ = 1;
+  TUSAS_DEVICE int mu_start_idx_ = 1;
+
+  TUSAS_DEVICE const int N_ETA_MAX_ = 4;
+  TUSAS_DEVICE int N_ETA_ = 1;
+  TUSAS_DEVICE int eta_start_idx_ = 1;
+  
+  TUSAS_DEVICE int eqn_off_ = 1;
+  TUSAS_DEVICE const int eqn_off_split_ = 2;
+
+  TUSAS_DEVICE int ci_ = 0;
+  TUSAS_DEVICE int mui_ = 1;
+  
+  TUSAS_DEVICE double t0_ = 1.;
+  TUSAS_DEVICE double x0_ = 1.;
+  TUSAS_DEVICE double f0_ = 1.;
+  TUSAS_DEVICE double k_c_ = 0.;
+  TUSAS_DEVICE double k_eta_ = 1.5;
+  TUSAS_DEVICE double M_ = 10.;
+  TUSAS_DEVICE double L_ = 2.;
+  TUSAS_DEVICE double w_ = 12.;
+
+  PARAM_FUNC(param_)
+  {
+    int N_p = plist->get<int>("N_ETA", N_ETA_);
+#ifdef TUSAS_HAVE_CUDA
+    cudaMemcpyToSymbol(N_ETA_, &N_p, sizeof(int));
+#else
+    N_ETA_ = N_p;
+#endif
+    int eqn_off_p = plist->get<int>("OFFSET", eqn_off_);
+#ifdef TUSAS_HAVE_CUDA
+    cudaMemcpyToSymbol(eqn_off_, &eqn_off_p, sizeof(int));
+#else
+    eqn_off_ = eqn_off_p;
+#endif
+    if(N_ETA_ > N_ETA_MAX_) exit(0);
+
+    // nondim free energy density, J/m^3
+    // generally, should be ~parabolicenergy::Aa_
+    f0_ = plist->get<double>("f0", f0_);
+    // nondim spatial scaling, m
+    x0_ = plist->get<double>("x0", x0_);
+    // nondim temporal scaling, s
+    t0_ = plist->get<double>("t0", t0_);
+
+    k_c_ = plist->get<double>("k_c", k_c_);
+    k_eta_ = plist->get<double>("k_eta", k_eta_);
+    M_ = plist->get<double>("M", M_);
+    L_ = plist->get<double>("L", L_);
+    w_ = plist->get<double>("w", w_);
+
+    // set params for free energy density
+    parabolicenergy::param_(plist);
+
+    // nondimensionalize
+    // note that if x0_, t0_, and f0_ are not
+    // set by the user in an input file, these
+    // values default to 1 and the original
+    // dimensional equations are preserved
+    parabolicenergy::Aa_ = parabolicenergy::Aa_ / f0_;
+    parabolicenergy::Ab_ = parabolicenergy::Ab_ / f0_;
+    parabolicenergy::f1_ = parabolicenergy::f1_ / f0_;
+    parabolicenergy::f2_ = parabolicenergy::f2_ / f0_;
+    k_c_ = k_c_ / x0_ / x0_ / f0_;
+    k_eta_ = k_eta_ / x0_ / x0_ / f0_;
+    M_ = M_ * t0_ * f0_ / x0_ / x0_;
+    L_ = L_ * t0_ * f0_;
+    w_ = w_ / f0_;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double mobility(const double hh) {
+    return M_ * (1. - hh) + hh;
+  } 
+
+  KOKKOS_INLINE_FUNCTION 
+  RES_FUNC_TPETRA(residual_eta)
+  {
+    const int Nt = 3;
+
+    const int local_id = eqn_id - eta_start_idx_;
+
+    const double phi = basis[0]->phi(i);
+    const double dphi_dx = basis[0]->dphidx(i);
+    const double dphi_dy = basis[0]->dphidy(i);
+    const double dphi_dz = basis[0]->dphidz(i);
+
+    double c[Nt_MAX_ * N_C_MAX_];
+    double dc_dx[Nt_MAX_ * N_C_MAX_];
+    double dc_dy[Nt_MAX_ * N_C_MAX_];
+    double dc_dz[Nt_MAX_ * N_C_MAX_];
+    tools::utils::get_uu(c, N_C_, N_C_MAX_, c_start_idx_, basis);
+    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, N_C_, N_C_MAX_, c_start_idx_, basis);
+
+    double eta[Nt_MAX_ * N_ETA_MAX_];
+    double deta_dx[Nt_MAX_ * N_ETA_MAX_];
+    double deta_dy[Nt_MAX_ * N_ETA_MAX_];
+    double deta_dz[Nt_MAX_ * N_ETA_MAX_];
+    tools::utils::get_uu(eta, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
+    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
+
+    double hh[Nt_MAX_];
+    double ca[Nt_MAX_];
+    double cb[Nt_MAX_];
+    double k_divgrad_eta[Nt_MAX_];
+    double df_deta[Nt_MAX_];
+    double f[Nt_MAX_];
+
+    int idx = 0;
+    for (int tdx = 0; tdx < Nt; ++tdx) {
+      hh[tdx] = parabolicenergy::h(&eta[tdx * N_ETA_MAX_]);
+      
+      ca[tdx] = parabolicenergy::c1_;
+      cb[tdx] = parabolicenergy::c2_;
+      idx = tools::utils::idx(tdx, local_id, N_C_MAX_);
+      tools::solvers::solve_kks(c[idx], hh[tdx], ca[tdx], cb[tdx],
+                                parabolicenergy::dfa_dca,
+                                parabolicenergy::dfb_dcb,
+                                parabolicenergy::d2fa_dca2,
+                                parabolicenergy::d2fb_dcb2);
+
+      idx = tools::utils::idx(tdx, local_id, N_ETA_MAX_);
+      df_deta[tdx] = (parabolicenergy::df_deta(ca[tdx], cb[tdx], eta[idx])
+                        + w_ * parabolicenergy::dg_deta(&eta[tdx * N_ETA_MAX_], local_id)) * phi;
+      k_divgrad_eta[tdx] = k_eta_ * (deta_dx[idx] * dphi_dx + deta_dy[idx] * dphi_dy + deta_dz[idx] * dphi_dz);
+
+      f[tdx] = L_* (k_divgrad_eta[tdx] + df_deta[tdx]);
+    }
+
+    const double deta_dt = (eta[tools::utils::idx(0, local_id, N_ETA_MAX_)] 
+                              - eta[tools::utils::idx(1, local_id, N_ETA_MAX_)]) / dt_ * phi;
+
+    return tools::utils::ret_value(deta_dt, f, dt_, dtold_, t_theta_, t_theta2_);
+
+    /*// test function
+    const double test = basis[0]->phi(i);
+    // u, phi
+    const double c[3] = {basis[ci_]->uu(), basis[ci_]->uuold(), basis[ci_]->uuoldold()};
+    const double eta[3] = {basis[eqn_id]->uu(), basis[eqn_id]->uuold(), basis[eqn_id]->uuoldold()};
+    const double divgradeta[3] = {L_ * k_eta_ * (basis[eqn_id]->duudx() * basis[0]->dphidx(i)
+                                    + basis[eqn_id]->duudy() * basis[0]->dphidy(i)
+                                    + basis[eqn_id]->duudz() * basis[0]->dphidz(i)),
+                                  L_ * k_eta_ * (basis[eqn_id]->duuolddx() * basis[0]->dphidx(i)
+                                    + basis[eqn_id]->duuolddy() * basis[0]->dphidy(i)
+                                    + basis[eqn_id]->duuolddz() * basis[0]->dphidz(i)),
+                                  L_ * k_eta_ * (basis[eqn_id]->duuoldolddx() * basis[0]->dphidx(i)
+                                    + basis[eqn_id]->duuoldolddy() * basis[0]->dphidy(i)
+                                    + basis[eqn_id]->duuoldolddz() * basis[0]->dphidz(i))};
+
+    double eta_array[N_ETA_MAX_];
+    double eta_array_old[N_ETA_MAX_];
+    double eta_array_oldold[N_ETA_MAX_];
+    for( int kk = 0; kk < N_ETA_; kk++){
+      int kk_off = kk + eqn_off_;
+      eta_array[kk] = basis[kk_off]->uu();
+      eta_array_old[kk] = basis[kk_off]->uuold();
+      eta_array_oldold[kk] = basis[kk_off]->uuoldold();
+    }
+
+    const double hh[3] = {parabolicenergy::h(eta_array),
+                          parabolicenergy::h(eta_array_old),
+                          parabolicenergy::h(eta_array_oldold)};
+    double ca[3] = {parabolicenergy::c1_, parabolicenergy::c1_, parabolicenergy::c1_};
+    double cb[3] = {parabolicenergy::c2_, parabolicenergy::c2_, parabolicenergy::c2_};
+    tools::solvers::solve_kks(c[0], hh[0], ca[0], cb[0],
+                   parabolicenergy::dfa_dca,
+                   parabolicenergy::dfb_dcb,
+                   parabolicenergy::d2fa_dca2,
+                   parabolicenergy::d2fb_dcb2);
+    tools::solvers::solve_kks(c[1], hh[1], ca[1], cb[1],
+                   parabolicenergy::dfa_dca,
+                   parabolicenergy::dfb_dcb,
+                   parabolicenergy::d2fa_dca2,
+                   parabolicenergy::d2fb_dcb2);
+    tools::solvers::solve_kks(c[2], hh[2], ca[2], cb[2],
+                   parabolicenergy::dfa_dca,
+                   parabolicenergy::dfb_dcb,
+                   parabolicenergy::d2fa_dca2,
+                   parabolicenergy::d2fb_dcb2);
+
+    const int k = eqn_id - eqn_off_;
+    const double df_deta[3] = {L_ * (parabolicenergy::df_deta(ca[0], cb[0], eta[0])
+                                 + w_ * parabolicenergy::dg_deta(eta_array, k)) * test,
+                               L_ * (parabolicenergy::df_deta(ca[1], cb[1], eta[1])
+                                 + w_ * parabolicenergy::dg_deta(eta_array_old, k)) * test,
+                               L_ * (parabolicenergy::df_deta(ca[2], cb[2], eta[2])
+                                 + w_ * parabolicenergy::dg_deta(eta_array_oldold, k)) * test};
+    
+    const double f[3] = {df_deta[0] + divgradeta[0],
+                         df_deta[1] + divgradeta[1],
+                         df_deta[2] + divgradeta[2]};
+
+    const double ut = (eta[0] - eta[1]) / dt_ * test;
+
+    return ut + (1. - t_theta2_) * t_theta_ * f[0]
+             + (1. - t_theta2_) * (1. - t_theta_) * f[1]
+             + .5 * t_theta2_ * ((2. + dt_ / dtold_) * f[1] - dt_ / dtold_ * f[2]);*/
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_eta_dp)) = residual_eta;
+
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(residual_c)
+  {
+    // number of time levels to compute
+    // might want to pass this in to res func?
+    const int Nt = 3;
+
+    // test function
+    const double phi = basis[0]->phi(i);
+    // grad(phi)
+    const double dphi_dx = basis[0]->dphidx(i);
+    const double dphi_dy = basis[0]->dphidy(i);
+    const double dphi_dz = basis[0]->dphidz(i);
+
+    // populate c viewed as a "matrix"
+    //   c[time_idx, c_idx]
+    // but really a 1D array that
+    // we can index this using
+    //   utils::idx(time_idx, c_idx, N_C_MAX_)
+    double c[Nt_MAX_ * N_C_MAX_] = {0.};
+    double dc_dx[Nt_MAX_ * N_C_MAX_] = {0.};
+    double dc_dy[Nt_MAX_ * N_C_MAX_] = {0.};
+    double dc_dz[Nt_MAX_ * N_C_MAX_] = {0.};
+    tools::utils::get_uu(c, N_C_, N_C_MAX_, c_start_idx_, basis);
+    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, N_C_, N_C_MAX_, c_start_idx_, basis);
+
+    // populate eta viewed as a "matrix"
+    //   eta[time_idx, eta_idx]
+    // but really a 1D array that
+    // we can index this using
+    //   utils::idx(time_idx, eta_idx, N_ETA_MAX_)
+    double eta[Nt_MAX_ * N_ETA_MAX_] = {0.};
+    double deta_dx[Nt_MAX_ * N_ETA_MAX_] = {0.};
+    double deta_dy[Nt_MAX_ * N_ETA_MAX_] = {0.};
+    double deta_dz[Nt_MAX_ * N_ETA_MAX_] = {0.};
+    tools::utils::get_uu(eta, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
+    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
+
+    // define all the variables we need to calculate 
+    // the residual = Mdivgrad_df_dc
+    double hh[Nt_MAX_] = {0.};
+    double dh_dx[Nt_MAX_] = {0.};
+    double dh_dy[Nt_MAX_] = {0.};
+    double dh_dz[Nt_MAX_] = {0.};
+    double ca[Nt_MAX_] = {0.};
+    double cb[Nt_MAX_] = {0.};
+    double d2f_dc2[Nt_MAX_] = {0.};
+    double d2f_dcdx[Nt_MAX_] = {0.};
+    double d2f_dcdy[Nt_MAX_] = {0.};
+    double d2f_dcdz[Nt_MAX_] = {0.};
+    double Mdivgrad_df_dc[Nt_MAX_] = {0.};
+
+
+    // loop over each time level that we need data at
+    int idx = 0;
+    double dh_deta = 0;
+    for (int tdx = 0; tdx < Nt; ++tdx) {
+      // calculate h
+      hh[tdx] = parabolicenergy::h(&eta[tdx * N_ETA_MAX_]);
+
+      // calculate grad h
+      dh_dx[tdx] = 0.;
+      dh_dy[tdx] = 0.;
+      dh_dz[tdx] = 0.;
+      for (int k = 0; k < N_ETA_ ; ++k) {
+        idx = tools::utils::idx(tdx, k, N_ETA_MAX_);
+        dh_deta = parabolicenergy::dh_deta(eta[idx]);
+
+        dh_dx[tdx] += dh_deta * deta_dx[idx];
+        dh_dy[tdx] += dh_deta * deta_dy[idx];
+        dh_dz[tdx] += dh_deta * deta_dz[idx];
+      }
+
+      // do the kks solve to get ca and cb
+      // for the current component c_{eqn_id}
+      ca[tdx] = parabolicenergy::c1_;
+      cb[tdx] = parabolicenergy::c2_;
+      tools::solvers::solve_kks(c[tools::utils::idx(tdx, eqn_id, N_C_MAX_)],
+                                hh[tdx],
+                                ca[tdx],
+                                cb[tdx],
+                                parabolicenergy::dfa_dca,
+                                parabolicenergy::dfb_dcb,
+                                parabolicenergy::d2fa_dca2,
+                                parabolicenergy::d2fb_dcb2);
+
+      // calculate d2f_dc2 using KKS eq 29 
+      d2f_dc2[tdx] = parabolicenergy::d2fa_dca2() * parabolicenergy::d2fb_dcb2() 
+                       / ((1 - hh[tdx]) * parabolicenergy::d2fa_dca2() + hh[tdx] * parabolicenergy::d2fb_dcb2());
+
+      // calculating grad(f_c) based on KKS eq 33, assuming M = D / f_cc
+      // this also follows from eq 30 and the chain rule
+      //   grad(f_c) = f_cc * h' * (cb - ca) * grad(eta) + f_cc * grad(c) 
+      //             = f_cc * (cb - ca) * grad(h) + f_cc * grad(c) 
+      idx = tools::utils::idx(tdx, eqn_id, N_C_MAX_);
+      d2f_dcdx[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dx[tdx] + d2f_dc2[tdx] * dc_dx[idx];
+      d2f_dcdy[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dy[tdx] + d2f_dc2[tdx] * dc_dy[idx];
+      d2f_dcdz[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dz[tdx] + d2f_dc2[tdx] * dc_dz[idx];
+
+      // finally, calculate M * div(grad(f_c))
+      Mdivgrad_df_dc[tdx] = mobility(hh[tdx]) * (d2f_dcdx[tdx] * dphi_dx
+                                                 + d2f_dcdy[tdx] * dphi_dy
+                                                 + d2f_dcdz[tdx] * dphi_dz);
+    }  // tdx = 0, < Nt loop
+
+    const double dc_dt = (c[tools::utils::idx(0, eqn_id, N_C_MAX_)] 
+                            - c[tools::utils::idx(1, eqn_id, N_C_MAX_)]) / dt_ * phi;
+
+    return tools::utils::ret_value(dc_dt, Mdivgrad_df_dc, dt_, dtold_, t_theta_, t_theta2_);
+  }
+  TUSAS_DEVICE RES_FUNC_TPETRA((*residual_c_dp)) = residual_c;
+  
+  KOKKOS_INLINE_FUNCTION 
+  PRE_FUNC_TPETRA(prec_eta_)
+  {
+    const double ut = basis[0]->phi(j) / dt_ * basis[0]->phi(i);
+    const double divgrad = L_ * k_eta_ * (basis[0]->dphidx(j) * basis[0]->dphidx(i)
+                           + basis[0]->dphidy(j) * basis[0]->dphidy(i)
+                           + basis[0]->dphidz(j) * basis[0]->dphidz(i));
+    return ut + t_theta_ * divgrad;
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  PRE_FUNC_TPETRA(prec_c_)
+  {
+    const double test = basis[0]->phi(i);
+    const double u_t = test * basis[0]->phi(j) / dt_;
+    
+    double eta_array[N_ETA_MAX_];
+    for(int kk = 0; kk < N_ETA_; kk++){
+      int kk_off = kk + eqn_off_;
+      eta_array[kk] = basis[kk_off]->uu();
+    }
+    
+    const double hh = parabolicenergy::h(eta_array);
+    // note that we can skip the kks solve here only
+    // because the free energy is parabolic -- the
+    // second derivatives are constant
+    const double d2f_dc2 = parabolicenergy::d2fa_dca2() * parabolicenergy::d2fb_dcb2() 
+                             / ((1 - hh) * parabolicenergy::d2fa_dca2() + hh * parabolicenergy::d2fb_dcb2());
+    const double divgradc = mobility(hh) * d2f_dc2 * (basis[0]->dphidx(j) * basis[0]->dphidx(i)
+                             + basis[0]->dphidy(j) * basis[0]->dphidy(i)
+                             + basis[0]->dphidz(j) * basis[0]->dphidz(i));
+    return u_t + t_theta_ * divgradc;
+  }
+
+  INI_FUNC(init_eta_)
+  {
+    std::cout << "init eta" << std::endl;
+    const double sqrt2 = std::sqrt(2.);
+    const double sqrtw = std::sqrt(w_);
+    
+    // this is l = xi * sqrt(2 * k_eta_) / sqrtw with xi = 1 instead of 4
+    const double l = std::sqrt(2 * k_eta_) / sqrtw;
+    return 0.5 * (1. - tanh((x - 30.) / (l * sqrt2)));
+    //return x < 30 ? 1 : 0;
+  }
+
+  INI_FUNC(init_c_)
+  {
+    const double eta = init_eta_(x, y, z, eqn_id, lid);
+    const double hh = parabolicenergy::h(&eta);
+    return parabolicenergy::c1_ * hh + parabolicenergy::c2_ * (1. - hh);
+  }
+
+}  // namespace tonks1
+
+    
+}  // namespace cases
+
+
+#endif  // ifndef CASES_HPP
+

--- a/timestep/include/cases.hpp
+++ b/timestep/include/cases.hpp
@@ -40,38 +40,38 @@ namespace parabolicenergy
    * where we assume that ca = cb = c for non-kks solves
    *
    */
-  TUSAS_DEVICE double Aa_ = 2.;
-  TUSAS_DEVICE double Ab_ = 2.;
-  TUSAS_DEVICE double c1_ = 0.3;
-  TUSAS_DEVICE double c2_ = 0.7;
-  TUSAS_DEVICE double delta_c1_ = 0.;
-  TUSAS_DEVICE double delta_c2_ = 0.;
-  TUSAS_DEVICE double f1_ = 0.;
-  TUSAS_DEVICE double f2_ = 0.;
-  TUSAS_DEVICE const double alpha_ = 5.;  // pfhub2 coef in g
+  TUSAS_DEVICE double Aa = 2.;
+  TUSAS_DEVICE double Ab = 2.;
+  TUSAS_DEVICE double c1 = 0.3;
+  TUSAS_DEVICE double c2 = 0.7;
+  TUSAS_DEVICE double delta_c1 = 0.;
+  TUSAS_DEVICE double delta_c2 = 0.;
+  TUSAS_DEVICE double f1 = 0.;
+  TUSAS_DEVICE double f2 = 0.;
+  TUSAS_DEVICE const double alpha = 5.;  // pfhub2 coef in g
   
-  TUSAS_DEVICE const int N_ETA_MAX = 4;
-  TUSAS_DEVICE int N_ETA_ = 1;
+  TUSAS_DEVICE const int Neta_max = 4;
+  TUSAS_DEVICE int Neta = 1;
 
-  PARAM_FUNC(param_)
+  PARAM_FUNC(param)
   {
-    int N_p = plist->get<int>("N_ETA", N_ETA_);
+    int Np = plist->get<int>("N_ETA", Neta);
 #ifdef TUSAS_HAVE_CUDA
-    cudaMemcpyToSymbol(N_ETA_, &N_p, sizeof(int));
+    cudaMemcpyToSymbol(Neta, &Np, sizeof(int));
 #else
-    N_ETA_ = N_p;
+    Neta = Np;
 #endif
-    if(N_ETA_ > N_ETA_MAX) exit(0);
+    if(Neta > Neta_max) exit(0);
 
     // parameters from Sheng 2022, eqns 8, 9
-    Aa_ = plist->get<double>("Aa", Aa_);
-    Ab_ = plist->get<double>("Ab", Ab_);
-    c1_ = plist->get<double>("c1", c1_);
-    c2_ = plist->get<double>("c2", c2_);
-    delta_c1_ = plist->get<double>("delta_c1", delta_c1_);
-    delta_c2_ = plist->get<double>("delta_c2", delta_c2_);
-    f1_ = plist->get<double>("f1", f1_);
-    f2_ = plist->get<double>("f2", f2_);
+    Aa = plist->get<double>("Aa", Aa);
+    Ab = plist->get<double>("Ab", Ab);
+    c1 = plist->get<double>("c1", c1);
+    c2 = plist->get<double>("c2", c2);
+    delta_c1 = plist->get<double>("delta_c1", delta_c1);
+    delta_c2 = plist->get<double>("delta_c2", delta_c2);
+    f1 = plist->get<double>("f1", f1);
+    f2 = plist->get<double>("f2", f2);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -79,47 +79,47 @@ namespace parabolicenergy
   {
     // f_alpha(c_alpha) from Sheng 2022, eqn 8
     // altered to be more general as eqn 9
-    return Aa_ * (ca - (c1_ + delta_c1_))
-               * (ca - (c1_ + delta_c1_)) + f1_;
+    return Aa * (ca - (c1 + delta_c1))
+              * (ca - (c1 + delta_c1)) + f1;
   }
 
   KOKKOS_INLINE_FUNCTION
   const double fb(const double cb)
   {
     // f_beta(c_beta) from Sheng 2022, eqn 9
-    return Ab_ * (cb - (c2_ + delta_c2_))
-               * (cb - (c2_ + delta_c2_)) + f2_;
+    return Ab * (cb - (c2 + delta_c2))
+              * (cb - (c2 + delta_c2)) + f2;
   }
 
   KOKKOS_INLINE_FUNCTION
   const double dfa_dca(const double ca)
   {
-    return 2 * Aa_ * (ca - (c1_ + delta_c1_));
+    return 2 * Aa * (ca - (c1 + delta_c1));
   }
 
   KOKKOS_INLINE_FUNCTION
   const double dfb_dcb(const double cb)
   {
-    return 2 * Ab_ * (cb - (c2_ + delta_c2_));
+    return 2 * Ab * (cb - (c2 + delta_c2));
   }
 
   KOKKOS_INLINE_FUNCTION
   const double d2fa_dca2()
   {
-    return 2 * Aa_;
+    return 2 * Aa;
   }
 
   KOKKOS_INLINE_FUNCTION
   const double d2fb_dcb2()
   {
-    return 2 * Ab_;
+    return 2 * Ab;
   }
 
   KOKKOS_INLINE_FUNCTION 
   const double h(const double *eta)
   {
     double val = 0.;
-    for (int i = 0; i < N_ETA_; i++) {
+    for (int i = 0; i < Neta; i++) {
       val += eta[i] * eta[i] * eta[i] 
                * (6. * eta[i] * eta[i] - 15. * eta[i] + 10.);
     }
@@ -136,13 +136,13 @@ namespace parabolicenergy
   const double dg_deta(const double *eta, const int eqn_id)
   {
     double aval = 0.;
-    for (int i = 0; i < N_ETA_; i++) {
+    for (int i = 0; i < Neta; i++) {
       aval += eta[i] * eta[i];
     }
     aval = aval - eta[eqn_id]*eta[eqn_id];
     return 2. * eta[eqn_id] * (1. - eta[eqn_id]) * (1. - eta[eqn_id])  
              - 2. * eta[eqn_id] * eta[eqn_id] * (1. - eta[eqn_id])
-             + 4. * alpha_ * eta[eqn_id] * aval;
+             + 4. * alpha * eta[eqn_id] * aval;
   }
 
   KOKKOS_INLINE_FUNCTION 
@@ -216,87 +216,75 @@ namespace parabolicenergy
 namespace tonks1
 {
  
-  TUSAS_DEVICE const int Nt_MAX_ = 3;
+  TUSAS_DEVICE const int Nt_max = 3;
   
-  TUSAS_DEVICE const int N_C_MAX_ = 2;
-  TUSAS_DEVICE int N_C_ = 1;
-  TUSAS_DEVICE int c_start_idx_ = 0;
+  TUSAS_DEVICE const int Nc_max = 2;
+  TUSAS_DEVICE int Nc = 1;
+  TUSAS_DEVICE int c_start_idx = 0;
 
-  TUSAS_DEVICE const int N_MU_MAX_ = 2;
-  TUSAS_DEVICE int N_MU_ = 1;
-  TUSAS_DEVICE int mu_start_idx_ = 1;
+  TUSAS_DEVICE const int Nmu_max = 2;
+  TUSAS_DEVICE int Nmu = 1;
+  TUSAS_DEVICE int mu_start_idx = 1;
 
-  TUSAS_DEVICE const int N_ETA_MAX_ = 4;
-  TUSAS_DEVICE int N_ETA_ = 1;
-  TUSAS_DEVICE int eta_start_idx_ = 1;
+  TUSAS_DEVICE const int Neta_max = 4;
+  TUSAS_DEVICE int Neta = 1;
+  TUSAS_DEVICE int eta_start_idx = 1;
   
-  TUSAS_DEVICE int eqn_off_ = 1;
-  TUSAS_DEVICE const int eqn_off_split_ = 2;
+  TUSAS_DEVICE double t0 = 1.;
+  TUSAS_DEVICE double x0 = 1.;
+  TUSAS_DEVICE double f0 = 1.;
+  TUSAS_DEVICE double k_c = 0.;
+  TUSAS_DEVICE double k_eta = 1.5;
+  TUSAS_DEVICE double M = 10.;
+  TUSAS_DEVICE double L = 2.;
+  TUSAS_DEVICE double w = 12.;
 
-  TUSAS_DEVICE int ci_ = 0;
-  TUSAS_DEVICE int mui_ = 1;
-  
-  TUSAS_DEVICE double t0_ = 1.;
-  TUSAS_DEVICE double x0_ = 1.;
-  TUSAS_DEVICE double f0_ = 1.;
-  TUSAS_DEVICE double k_c_ = 0.;
-  TUSAS_DEVICE double k_eta_ = 1.5;
-  TUSAS_DEVICE double M_ = 10.;
-  TUSAS_DEVICE double L_ = 2.;
-  TUSAS_DEVICE double w_ = 12.;
-
-  PARAM_FUNC(param_)
+  PARAM_FUNC(param)
   {
-    int N_p = plist->get<int>("N_ETA", N_ETA_);
+    int Np = plist->get<int>("N_ETA", Neta);
 #ifdef TUSAS_HAVE_CUDA
-    cudaMemcpyToSymbol(N_ETA_, &N_p, sizeof(int));
+    cudaMemcpyToSymbol(Neta, &Np, sizeof(int));
 #else
-    N_ETA_ = N_p;
+    Neta = Np;
 #endif
-    int eqn_off_p = plist->get<int>("OFFSET", eqn_off_);
-#ifdef TUSAS_HAVE_CUDA
-    cudaMemcpyToSymbol(eqn_off_, &eqn_off_p, sizeof(int));
-#else
-    eqn_off_ = eqn_off_p;
-#endif
-    if(N_ETA_ > N_ETA_MAX_) exit(0);
+    if(Neta > Neta_max) exit(0);
 
     // nondim free energy density, J/m^3
     // generally, should be ~parabolicenergy::Aa_
-    f0_ = plist->get<double>("f0", f0_);
+    f0 = plist->get<double>("f0", f0);
     // nondim spatial scaling, m
-    x0_ = plist->get<double>("x0", x0_);
+    x0 = plist->get<double>("x0", x0);
     // nondim temporal scaling, s
-    t0_ = plist->get<double>("t0", t0_);
+    t0 = plist->get<double>("t0", t0);
 
-    k_c_ = plist->get<double>("k_c", k_c_);
-    k_eta_ = plist->get<double>("k_eta", k_eta_);
-    M_ = plist->get<double>("M", M_);
-    L_ = plist->get<double>("L", L_);
-    w_ = plist->get<double>("w", w_);
+    k_c = plist->get<double>("k_c", k_c);
+    k_eta = plist->get<double>("k_eta", k_eta);
+    M = plist->get<double>("M", M);
+    L = plist->get<double>("L", L);
+    w = plist->get<double>("w", w);
 
     // set params for free energy density
-    parabolicenergy::param_(plist);
+    parabolicenergy::param(plist);
 
     // nondimensionalize
     // note that if x0_, t0_, and f0_ are not
     // set by the user in an input file, these
     // values default to 1 and the original
     // dimensional equations are preserved
-    parabolicenergy::Aa_ = parabolicenergy::Aa_ / f0_;
-    parabolicenergy::Ab_ = parabolicenergy::Ab_ / f0_;
-    parabolicenergy::f1_ = parabolicenergy::f1_ / f0_;
-    parabolicenergy::f2_ = parabolicenergy::f2_ / f0_;
-    k_c_ = k_c_ / x0_ / x0_ / f0_;
-    k_eta_ = k_eta_ / x0_ / x0_ / f0_;
-    M_ = M_ * t0_ * f0_ / x0_ / x0_;
-    L_ = L_ * t0_ * f0_;
-    w_ = w_ / f0_;
+    parabolicenergy::Aa = parabolicenergy::Aa / f0;
+    parabolicenergy::Ab = parabolicenergy::Ab / f0;
+    parabolicenergy::f1 = parabolicenergy::f1 / f0;
+    parabolicenergy::f2 = parabolicenergy::f2 / f0;
+    k_c = k_c / x0 / x0 / f0;
+    k_eta = k_eta / x0 / x0 / f0;
+    M = M * t0 * f0 / x0 / x0;
+    L = L * t0 * f0;
+    w = w / f0;
   }
 
   KOKKOS_INLINE_FUNCTION
   const double mobility(const double hh) {
-    return M_ * (1. - hh) + hh;
+    return M * (1. - hh) + hh;
   } 
 
   KOKKOS_INLINE_FUNCTION 
@@ -304,123 +292,59 @@ namespace tonks1
   {
     const int Nt = 3;
 
-    const int local_id = eqn_id - eta_start_idx_;
+    const int local_id = eqn_id - eta_start_idx;
 
     const double phi = basis[0]->phi(i);
     const double dphi_dx = basis[0]->dphidx(i);
     const double dphi_dy = basis[0]->dphidy(i);
     const double dphi_dz = basis[0]->dphidz(i);
 
-    double c[Nt_MAX_ * N_C_MAX_];
-    double dc_dx[Nt_MAX_ * N_C_MAX_];
-    double dc_dy[Nt_MAX_ * N_C_MAX_];
-    double dc_dz[Nt_MAX_ * N_C_MAX_];
-    tools::utils::get_uu(c, N_C_, N_C_MAX_, c_start_idx_, basis);
-    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, N_C_, N_C_MAX_, c_start_idx_, basis);
+    double c[Nt_max * Nc_max];
+    double dc_dx[Nt_max * Nc_max];
+    double dc_dy[Nt_max * Nc_max];
+    double dc_dz[Nt_max * Nc_max];
+    tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
+    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
 
-    double eta[Nt_MAX_ * N_ETA_MAX_];
-    double deta_dx[Nt_MAX_ * N_ETA_MAX_];
-    double deta_dy[Nt_MAX_ * N_ETA_MAX_];
-    double deta_dz[Nt_MAX_ * N_ETA_MAX_];
-    tools::utils::get_uu(eta, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
-    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
+    double eta[Nt_max * Neta_max];
+    double deta_dx[Nt_max * Neta_max];
+    double deta_dy[Nt_max * Neta_max];
+    double deta_dz[Nt_max * Neta_max];
+    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
+    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
 
-    double hh[Nt_MAX_];
-    double ca[Nt_MAX_];
-    double cb[Nt_MAX_];
-    double k_divgrad_eta[Nt_MAX_];
-    double df_deta[Nt_MAX_];
-    double f[Nt_MAX_];
+    double hh[Nt_max];
+    double ca[Nt_max];
+    double cb[Nt_max];
+    double k_divgrad_eta[Nt_max];
+    double df_deta[Nt_max];
+    double f[Nt_max];
 
     int idx = 0;
     for (int tdx = 0; tdx < Nt; ++tdx) {
-      hh[tdx] = parabolicenergy::h(&eta[tdx * N_ETA_MAX_]);
+      hh[tdx] = parabolicenergy::h(&eta[tdx * Neta_max]);
       
-      ca[tdx] = parabolicenergy::c1_;
-      cb[tdx] = parabolicenergy::c2_;
-      idx = tools::utils::idx(tdx, local_id, N_C_MAX_);
+      ca[tdx] = parabolicenergy::c1;
+      cb[tdx] = parabolicenergy::c2;
+      idx = tools::utils::idx(tdx, local_id, Nc_max);
       tools::solvers::solve_kks(c[idx], hh[tdx], ca[tdx], cb[tdx],
                                 parabolicenergy::dfa_dca,
                                 parabolicenergy::dfb_dcb,
                                 parabolicenergy::d2fa_dca2,
                                 parabolicenergy::d2fb_dcb2);
 
-      idx = tools::utils::idx(tdx, local_id, N_ETA_MAX_);
+      idx = tools::utils::idx(tdx, local_id, Neta_max);
       df_deta[tdx] = (parabolicenergy::df_deta(ca[tdx], cb[tdx], eta[idx])
-                        + w_ * parabolicenergy::dg_deta(&eta[tdx * N_ETA_MAX_], local_id)) * phi;
-      k_divgrad_eta[tdx] = k_eta_ * (deta_dx[idx] * dphi_dx + deta_dy[idx] * dphi_dy + deta_dz[idx] * dphi_dz);
+                        + w * parabolicenergy::dg_deta(&eta[tdx * Neta_max], local_id)) * phi;
+      k_divgrad_eta[tdx] = k_eta * (deta_dx[idx] * dphi_dx + deta_dy[idx] * dphi_dy + deta_dz[idx] * dphi_dz);
 
-      f[tdx] = L_* (k_divgrad_eta[tdx] + df_deta[tdx]);
+      f[tdx] = L* (k_divgrad_eta[tdx] + df_deta[tdx]);
     }
 
-    const double deta_dt = (eta[tools::utils::idx(0, local_id, N_ETA_MAX_)] 
-                              - eta[tools::utils::idx(1, local_id, N_ETA_MAX_)]) / dt_ * phi;
+    const double deta_dt = (eta[tools::utils::idx(0, local_id, Neta_max)] 
+                              - eta[tools::utils::idx(1, local_id, Neta_max)]) / dt_ * phi;
 
     return tools::utils::ret_value(deta_dt, f, dt_, dtold_, t_theta_, t_theta2_);
-
-    /*// test function
-    const double test = basis[0]->phi(i);
-    // u, phi
-    const double c[3] = {basis[ci_]->uu(), basis[ci_]->uuold(), basis[ci_]->uuoldold()};
-    const double eta[3] = {basis[eqn_id]->uu(), basis[eqn_id]->uuold(), basis[eqn_id]->uuoldold()};
-    const double divgradeta[3] = {L_ * k_eta_ * (basis[eqn_id]->duudx() * basis[0]->dphidx(i)
-                                    + basis[eqn_id]->duudy() * basis[0]->dphidy(i)
-                                    + basis[eqn_id]->duudz() * basis[0]->dphidz(i)),
-                                  L_ * k_eta_ * (basis[eqn_id]->duuolddx() * basis[0]->dphidx(i)
-                                    + basis[eqn_id]->duuolddy() * basis[0]->dphidy(i)
-                                    + basis[eqn_id]->duuolddz() * basis[0]->dphidz(i)),
-                                  L_ * k_eta_ * (basis[eqn_id]->duuoldolddx() * basis[0]->dphidx(i)
-                                    + basis[eqn_id]->duuoldolddy() * basis[0]->dphidy(i)
-                                    + basis[eqn_id]->duuoldolddz() * basis[0]->dphidz(i))};
-
-    double eta_array[N_ETA_MAX_];
-    double eta_array_old[N_ETA_MAX_];
-    double eta_array_oldold[N_ETA_MAX_];
-    for( int kk = 0; kk < N_ETA_; kk++){
-      int kk_off = kk + eqn_off_;
-      eta_array[kk] = basis[kk_off]->uu();
-      eta_array_old[kk] = basis[kk_off]->uuold();
-      eta_array_oldold[kk] = basis[kk_off]->uuoldold();
-    }
-
-    const double hh[3] = {parabolicenergy::h(eta_array),
-                          parabolicenergy::h(eta_array_old),
-                          parabolicenergy::h(eta_array_oldold)};
-    double ca[3] = {parabolicenergy::c1_, parabolicenergy::c1_, parabolicenergy::c1_};
-    double cb[3] = {parabolicenergy::c2_, parabolicenergy::c2_, parabolicenergy::c2_};
-    tools::solvers::solve_kks(c[0], hh[0], ca[0], cb[0],
-                   parabolicenergy::dfa_dca,
-                   parabolicenergy::dfb_dcb,
-                   parabolicenergy::d2fa_dca2,
-                   parabolicenergy::d2fb_dcb2);
-    tools::solvers::solve_kks(c[1], hh[1], ca[1], cb[1],
-                   parabolicenergy::dfa_dca,
-                   parabolicenergy::dfb_dcb,
-                   parabolicenergy::d2fa_dca2,
-                   parabolicenergy::d2fb_dcb2);
-    tools::solvers::solve_kks(c[2], hh[2], ca[2], cb[2],
-                   parabolicenergy::dfa_dca,
-                   parabolicenergy::dfb_dcb,
-                   parabolicenergy::d2fa_dca2,
-                   parabolicenergy::d2fb_dcb2);
-
-    const int k = eqn_id - eqn_off_;
-    const double df_deta[3] = {L_ * (parabolicenergy::df_deta(ca[0], cb[0], eta[0])
-                                 + w_ * parabolicenergy::dg_deta(eta_array, k)) * test,
-                               L_ * (parabolicenergy::df_deta(ca[1], cb[1], eta[1])
-                                 + w_ * parabolicenergy::dg_deta(eta_array_old, k)) * test,
-                               L_ * (parabolicenergy::df_deta(ca[2], cb[2], eta[2])
-                                 + w_ * parabolicenergy::dg_deta(eta_array_oldold, k)) * test};
-    
-    const double f[3] = {df_deta[0] + divgradeta[0],
-                         df_deta[1] + divgradeta[1],
-                         df_deta[2] + divgradeta[2]};
-
-    const double ut = (eta[0] - eta[1]) / dt_ * test;
-
-    return ut + (1. - t_theta2_) * t_theta_ * f[0]
-             + (1. - t_theta2_) * (1. - t_theta_) * f[1]
-             + .5 * t_theta2_ * ((2. + dt_ / dtold_) * f[1] - dt_ / dtold_ * f[2]);*/
   }
   TUSAS_DEVICE RES_FUNC_TPETRA((*residual_eta_dp)) = residual_eta;
 
@@ -442,39 +366,39 @@ namespace tonks1
     //   c[time_idx, c_idx]
     // but really a 1D array that
     // we can index this using
-    //   utils::idx(time_idx, c_idx, N_C_MAX_)
-    double c[Nt_MAX_ * N_C_MAX_] = {0.};
-    double dc_dx[Nt_MAX_ * N_C_MAX_] = {0.};
-    double dc_dy[Nt_MAX_ * N_C_MAX_] = {0.};
-    double dc_dz[Nt_MAX_ * N_C_MAX_] = {0.};
-    tools::utils::get_uu(c, N_C_, N_C_MAX_, c_start_idx_, basis);
-    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, N_C_, N_C_MAX_, c_start_idx_, basis);
+    //   utils::idx(time_idx, c_idx, Nc_max)
+    double c[Nt_max * Nc_max] = {0.};
+    double dc_dx[Nt_max * Nc_max] = {0.};
+    double dc_dy[Nt_max * Nc_max] = {0.};
+    double dc_dz[Nt_max * Nc_max] = {0.};
+    tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
+    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
 
     // populate eta viewed as a "matrix"
     //   eta[time_idx, eta_idx]
     // but really a 1D array that
     // we can index this using
-    //   utils::idx(time_idx, eta_idx, N_ETA_MAX_)
-    double eta[Nt_MAX_ * N_ETA_MAX_] = {0.};
-    double deta_dx[Nt_MAX_ * N_ETA_MAX_] = {0.};
-    double deta_dy[Nt_MAX_ * N_ETA_MAX_] = {0.};
-    double deta_dz[Nt_MAX_ * N_ETA_MAX_] = {0.};
-    tools::utils::get_uu(eta, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
-    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, N_ETA_, N_ETA_MAX_, eta_start_idx_, basis);
+    //   utils::idx(time_idx, eta_idx, Neta_max)
+    double eta[Nt_max * Neta_max] = {0.};
+    double deta_dx[Nt_max * Neta_max] = {0.};
+    double deta_dy[Nt_max * Neta_max] = {0.};
+    double deta_dz[Nt_max * Neta_max] = {0.};
+    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
+    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
 
     // define all the variables we need to calculate 
     // the residual = Mdivgrad_df_dc
-    double hh[Nt_MAX_] = {0.};
-    double dh_dx[Nt_MAX_] = {0.};
-    double dh_dy[Nt_MAX_] = {0.};
-    double dh_dz[Nt_MAX_] = {0.};
-    double ca[Nt_MAX_] = {0.};
-    double cb[Nt_MAX_] = {0.};
-    double d2f_dc2[Nt_MAX_] = {0.};
-    double d2f_dcdx[Nt_MAX_] = {0.};
-    double d2f_dcdy[Nt_MAX_] = {0.};
-    double d2f_dcdz[Nt_MAX_] = {0.};
-    double Mdivgrad_df_dc[Nt_MAX_] = {0.};
+    double hh[Nt_max] = {0.};
+    double dh_dx[Nt_max] = {0.};
+    double dh_dy[Nt_max] = {0.};
+    double dh_dz[Nt_max] = {0.};
+    double ca[Nt_max] = {0.};
+    double cb[Nt_max] = {0.};
+    double d2f_dc2[Nt_max] = {0.};
+    double d2f_dcdx[Nt_max] = {0.};
+    double d2f_dcdy[Nt_max] = {0.};
+    double d2f_dcdz[Nt_max] = {0.};
+    double Mdivgrad_df_dc[Nt_max] = {0.};
 
 
     // loop over each time level that we need data at
@@ -482,14 +406,14 @@ namespace tonks1
     double dh_deta = 0;
     for (int tdx = 0; tdx < Nt; ++tdx) {
       // calculate h
-      hh[tdx] = parabolicenergy::h(&eta[tdx * N_ETA_MAX_]);
+      hh[tdx] = parabolicenergy::h(&eta[tdx * Neta_max]);
 
       // calculate grad h
       dh_dx[tdx] = 0.;
       dh_dy[tdx] = 0.;
       dh_dz[tdx] = 0.;
-      for (int k = 0; k < N_ETA_ ; ++k) {
-        idx = tools::utils::idx(tdx, k, N_ETA_MAX_);
+      for (int k = 0; k < Neta ; ++k) {
+        idx = tools::utils::idx(tdx, k, Neta_max);
         dh_deta = parabolicenergy::dh_deta(eta[idx]);
 
         dh_dx[tdx] += dh_deta * deta_dx[idx];
@@ -499,9 +423,9 @@ namespace tonks1
 
       // do the kks solve to get ca and cb
       // for the current component c_{eqn_id}
-      ca[tdx] = parabolicenergy::c1_;
-      cb[tdx] = parabolicenergy::c2_;
-      tools::solvers::solve_kks(c[tools::utils::idx(tdx, eqn_id, N_C_MAX_)],
+      ca[tdx] = parabolicenergy::c1;
+      cb[tdx] = parabolicenergy::c2;
+      tools::solvers::solve_kks(c[tools::utils::idx(tdx, eqn_id, Nc_max)],
                                 hh[tdx],
                                 ca[tdx],
                                 cb[tdx],
@@ -518,7 +442,7 @@ namespace tonks1
       // this also follows from eq 30 and the chain rule
       //   grad(f_c) = f_cc * h' * (cb - ca) * grad(eta) + f_cc * grad(c) 
       //             = f_cc * (cb - ca) * grad(h) + f_cc * grad(c) 
-      idx = tools::utils::idx(tdx, eqn_id, N_C_MAX_);
+      idx = tools::utils::idx(tdx, eqn_id, Nc_max);
       d2f_dcdx[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dx[tdx] + d2f_dc2[tdx] * dc_dx[idx];
       d2f_dcdy[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dy[tdx] + d2f_dc2[tdx] * dc_dy[idx];
       d2f_dcdz[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dz[tdx] + d2f_dc2[tdx] * dc_dz[idx];
@@ -529,32 +453,32 @@ namespace tonks1
                                                  + d2f_dcdz[tdx] * dphi_dz);
     }  // tdx = 0, < Nt loop
 
-    const double dc_dt = (c[tools::utils::idx(0, eqn_id, N_C_MAX_)] 
-                            - c[tools::utils::idx(1, eqn_id, N_C_MAX_)]) / dt_ * phi;
+    const double dc_dt = (c[tools::utils::idx(0, eqn_id, Nc_max)] 
+                            - c[tools::utils::idx(1, eqn_id, Nc_max)]) / dt_ * phi;
 
     return tools::utils::ret_value(dc_dt, Mdivgrad_df_dc, dt_, dtold_, t_theta_, t_theta2_);
   }
   TUSAS_DEVICE RES_FUNC_TPETRA((*residual_c_dp)) = residual_c;
   
   KOKKOS_INLINE_FUNCTION 
-  PRE_FUNC_TPETRA(prec_eta_)
+  PRE_FUNC_TPETRA(prec_eta)
   {
     const double ut = basis[0]->phi(j) / dt_ * basis[0]->phi(i);
-    const double divgrad = L_ * k_eta_ * (basis[0]->dphidx(j) * basis[0]->dphidx(i)
+    const double divgrad = L * k_eta * (basis[0]->dphidx(j) * basis[0]->dphidx(i)
                            + basis[0]->dphidy(j) * basis[0]->dphidy(i)
                            + basis[0]->dphidz(j) * basis[0]->dphidz(i));
     return ut + t_theta_ * divgrad;
   }
 
   KOKKOS_INLINE_FUNCTION 
-  PRE_FUNC_TPETRA(prec_c_)
+  PRE_FUNC_TPETRA(prec_c)
   {
     const double test = basis[0]->phi(i);
     const double u_t = test * basis[0]->phi(j) / dt_;
     
-    double eta_array[N_ETA_MAX_];
-    for(int kk = 0; kk < N_ETA_; kk++){
-      int kk_off = kk + eqn_off_;
+    double eta_array[Neta_max];
+    for(int kk = 0; kk < Neta; kk++){
+      int kk_off = kk + 1;
       eta_array[kk] = basis[kk_off]->uu();
     }
     
@@ -570,23 +494,23 @@ namespace tonks1
     return u_t + t_theta_ * divgradc;
   }
 
-  INI_FUNC(init_eta_)
+  INI_FUNC(init_eta)
   {
     std::cout << "init eta" << std::endl;
     const double sqrt2 = std::sqrt(2.);
-    const double sqrtw = std::sqrt(w_);
+    const double sqrtw = std::sqrt(w);
     
     // this is l = xi * sqrt(2 * k_eta_) / sqrtw with xi = 1 instead of 4
-    const double l = std::sqrt(2 * k_eta_) / sqrtw;
+    const double l = std::sqrt(2 * k_eta) / sqrtw;
     return 0.5 * (1. - tanh((x - 30.) / (l * sqrt2)));
     //return x < 30 ? 1 : 0;
   }
 
-  INI_FUNC(init_c_)
+  INI_FUNC(init_c)
   {
-    const double eta = init_eta_(x, y, z, eqn_id, lid);
+    const double eta = init_eta(x, y, z, eqn_id, lid);
     const double hh = parabolicenergy::h(&eta);
-    return parabolicenergy::c1_ * hh + parabolicenergy::c2_ * (1. - hh);
+    return parabolicenergy::c1 * hh + parabolicenergy::c2 * (1. - hh);
   }
 
 }  // namespace tonks1

--- a/timestep/include/pdes.hpp
+++ b/timestep/include/pdes.hpp
@@ -1,0 +1,122 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) Triad National Security, LLC.  This file is part of the
+//  Tusas code (LA-CC-17-001) and is subject to the revised BSD license terms
+//  in the LICENSE file found in the top-level directory of this distribution.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef PDES_HPP
+#define PDES_HPP
+
+
+#include <boost/ptr_container/ptr_vector.hpp>
+#include "basis.hpp"
+
+#include "tools.hpp"
+	
+#include "Teuchos_ParameterList.hpp"
+
+#include <Kokkos_Core.hpp>
+
+
+#if defined (KOKKOS_HAVE_CUDA) || defined (KOKKOS_ENABLE_CUDA) || (KOKKOS_HAVE_HIP) || defined (KOKKOS_ENABLE_HIP)
+#define TUSAS_DEVICE __device__
+#else
+#define TUSAS_DEVICE /**/ 
+#endif
+
+#if defined (KOKKOS_HAVE_CUDA) || defined (KOKKOS_ENABLE_CUDA)
+#define TUSAS_HAVE_CUDA
+#endif
+
+#if defined(KOKKOS_HAVE_HIP) || defined (KOKKOS_ENABLE_HIP)
+#define TUSAS_HAVE_HIP
+#endif
+
+
+/*
+ * Definition for residual function. Each residual function is called at each Gauss point 
+ * for each equation with this signature:
+ *   NAME: name of function to call
+ *   const boost::ptr_vector<Basis> &basis: an array of basis function objects indexed by equation
+ *   const int &i: the current test function (row in residual vector)
+ *   const double &dt_: the timestep size as prescribed in input file						
+ *   const double &t_theta_: the timestep parameter as prescribed in input file
+ *   const double &time: the current simulation time
+ *   const int &eqn_id: the index of the current equation
+ */
+#define RES_FUNC_TPETRA(NAME) const double NAME(GPUBasis *basis[], \
+                                                const int i, \
+                                                const double dt_, \
+                                                const double dtold_, \
+                                                const double t_theta_, \
+                                                const double t_theta2_, \
+                                                const double time, \
+                                                const int eqn_id, \
+                                                const double vol, \
+                                                const double rand)
+
+/*
+ * Definition for precondition function. Each precondition function is called at each Gauss point 
+ * for each equation with this signature:
+ *   NAME: name of function to call
+ *   const boost::ptr_vector<Basis> &basis: an array of basis function objects indexed by equation
+ *   const int &i: the current basis function (row in preconditioning matrix)
+ *   const int &j: the current test function (column in preconditioning matrix)
+ *   const double &dt_: the timestep size as prescribed in input file						
+ *   const double &t_theta_: the timestep parameter as prescribed in input file
+ *   const double &time: the current simulation time
+ *   const int &eqn_id: the index of the current equation
+ */
+#define PRE_FUNC_TPETRA(NAME) const double NAME(GPUBasis *basis[], \
+                                                const int i, \
+                                                const int j, \
+                                                const double dt_, \
+                                                const double t_theta_, \
+                                                const int eqn_id)
+
+/*
+ * Definition for post-process function. Each post-process function is called at each node for each equation at the 
+ * end of each timestep with this signature:
+ *   NAME: name of function to call
+ *   const double *u: an array of solution values indexed by equation
+ *   const double *gradu: an array of gradient values indexed by equation, coordinates (NULL unless error estimation is activated)
+ *   const double *xyz: an array of coordinates indexed by equation, coordinates
+ *   const double &time: the current simulation time
+ */
+#define PPR_FUNC(NAME) double NAME(const double *u, \
+                                   const double *uold, \
+                                   const double *uoldold, \
+                                   const double *gradu, \
+                                   const double *xyz, \
+                                   const double &time, \
+                                   const double &dt, \
+                                   const double &dtold, \
+                                   const int &eqn_id)
+
+/*
+ * Parameter function to propogate information from input file. Each parameter function is called at the beginning of each simulation.
+ *   NAME: name of function to call
+ *   Teuchos::ParameterList *plist: paramterlist containing information defined in input file
+ */
+#define PARAM_FUNC(NAME) void NAME(Teuchos::ParameterList *plist) 
+
+
+namespace pdes
+{
+
+
+namespace kks
+{
+  const int n_c_max = 4;
+  int n_c = 1;
+}  // namespace kks
+
+    
+}  // namespace pdes
+
+
+#endif  // ifndef PDES_HPP
+

--- a/timestep/include/pdes.hpp
+++ b/timestep/include/pdes.hpp
@@ -46,17 +46,21 @@
  *   const double &t_theta_: the timestep parameter as prescribed in input file
  *   const double &time: the current simulation time
  *   const int &eqn_id: the index of the current equation
+ * Note that this macro accepts optional arguments that are expended at __VA_ARGS__, separated by commas.
+ * This can be used to define a RES_FUNC_TPETRA here in pdes.hpp that has additional parameters to be 
+ * specified in cases.hpp 
  */
-#define RES_FUNC_TPETRA(NAME) const double NAME(GPUBasis *basis[], \
-                                                const int i, \
-                                                const double dt_, \
-                                                const double dtold_, \
-                                                const double t_theta_, \
-                                                const double t_theta2_, \
-                                                const double time, \
-                                                const int eqn_id, \
-                                                const double vol, \
-                                                const double rand)
+#define RES_FUNC_TPETRA(NAME, ...) const double NAME(GPUBasis *basis[], \
+                                                     const int i, \
+                                                     const double dt_, \
+                                                     const double dtold_, \
+                                                     const double t_theta_, \
+                                                     const double t_theta2_, \
+                                                     const double time, \
+                                                     const int eqn_id, \
+                                                     const double vol, \
+                                                     const double rand \
+                                                     __VA_OPT__(,) __VA_ARGS__)
 
 /*
  * Definition for precondition function. Each precondition function is called at each Gauss point 
@@ -69,13 +73,17 @@
  *   const double &t_theta_: the timestep parameter as prescribed in input file
  *   const double &time: the current simulation time
  *   const int &eqn_id: the index of the current equation
+ * Note that this macro accepts optional arguments that are expended at __VA_ARGS__, separated by commas.
+ * This can be used to define a PRE_FUNC_TPETRA here in pdes.hpp that has additional parameters to be
+ * specified in cases.hpp 
  */
-#define PRE_FUNC_TPETRA(NAME) const double NAME(GPUBasis *basis[], \
-                                                const int i, \
-                                                const int j, \
-                                                const double dt_, \
-                                                const double t_theta_, \
-                                                const int eqn_id)
+#define PRE_FUNC_TPETRA(NAME, ...) const double NAME(GPUBasis *basis[], \
+                                                     const int i, \
+                                                     const int j, \
+                                                     const double dt_, \
+                                                     const double t_theta_, \
+                                                     const int eqn_id \
+                                                     __VA_OPT__(,) __VA_ARGS__)
 
 /*
  * Definition for post-process function. Each post-process function is called at each node for each equation at the 
@@ -108,10 +116,515 @@ namespace pdes
 {
 
 
+namespace parabolicenergy
+{
+  /*
+   *
+   * This namespace implements parabolic free energy
+   * density functions, their derivatives, and related
+   * functions
+   *
+   * As in the kks namespace, this implementation assumes
+   * two phases, an a-phase ("solid") and a b-phase ("liquid"):
+   *   a corresponds to eta
+   *   b corresponds to 1 - eta
+   *
+   * The free energy density functions are
+   *   fa(ca) = Aa_ * (ca - (c1_ + delta_c1_))^2 + f1_
+   *   fb(cb) = Ab_ * (cb - (c2_ + delta_c2_))^2 + f2_
+   *
+   * We also supply overloaded versions of relevant functions
+   * where we assume that ca = cb = c for non-kks solves
+   *
+   */
+  TUSAS_DEVICE double Aa = 2.;
+  TUSAS_DEVICE double Ab = 2.;
+  TUSAS_DEVICE double c1 = 0.3;
+  TUSAS_DEVICE double c2 = 0.7;
+  TUSAS_DEVICE double delta_c1 = 0.;
+  TUSAS_DEVICE double delta_c2 = 0.;
+  TUSAS_DEVICE double f1 = 0.;
+  TUSAS_DEVICE double f2 = 0.;
+  TUSAS_DEVICE const double alpha = 5.;  // pfhub2 coef in g
+  
+  TUSAS_DEVICE const int Neta_max = 4;
+  TUSAS_DEVICE int Neta = 1;
+
+  PARAM_FUNC(param)
+  {
+    int Np = plist->get<int>("N_ETA", Neta);
+#ifdef TUSAS_HAVE_CUDA
+    cudaMemcpyToSymbol(Neta, &Np, sizeof(int));
+#else
+    Neta = Np;
+#endif
+    if(Neta > Neta_max) exit(0);
+
+    // parameters from Sheng 2022, eqns 8, 9
+    Aa = plist->get<double>("Aa", Aa);
+    Ab = plist->get<double>("Ab", Ab);
+    c1 = plist->get<double>("c1", c1);
+    c2 = plist->get<double>("c2", c2);
+    delta_c1 = plist->get<double>("delta_c1", delta_c1);
+    delta_c2 = plist->get<double>("delta_c2", delta_c2);
+    f1 = plist->get<double>("f1", f1);
+    f2 = plist->get<double>("f2", f2);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double fa(const double ca)
+  {
+    // f_alpha(c_alpha) from Sheng 2022, eqn 8
+    // altered to be more general as eqn 9
+    return Aa * (ca - (c1 + delta_c1))
+              * (ca - (c1 + delta_c1)) + f1;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double fb(const double cb)
+  {
+    // f_beta(c_beta) from Sheng 2022, eqn 9
+    return Ab * (cb - (c2 + delta_c2))
+              * (cb - (c2 + delta_c2)) + f2;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double dfa_dca(const double ca)
+  {
+    return 2 * Aa * (ca - (c1 + delta_c1));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double dfb_dcb(const double cb)
+  {
+    return 2 * Ab * (cb - (c2 + delta_c2));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double d2fa_dca2()
+  {
+    return 2 * Aa;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double d2fb_dcb2()
+  {
+    return 2 * Ab;
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double h(const double *eta)
+  {
+    double val = 0.;
+    for (int i = 0; i < Neta; i++) {
+      val += eta[i] * eta[i] * eta[i] 
+               * (6. * eta[i] * eta[i] - 15. * eta[i] + 10.);
+    }
+    return val;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  double dh_deta(const double eta)
+  {
+    return eta * eta * ((30. * eta - 60.) * eta + 30.);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double dg_deta(const double *eta, const int eqn_id)
+  {
+    double aval = 0.;
+    for (int i = 0; i < Neta; i++) {
+      aval += eta[i] * eta[i];
+    }
+    aval = aval - eta[eqn_id]*eta[eqn_id];
+    return 2. * eta[eqn_id] * (1. - eta[eqn_id]) * (1. - eta[eqn_id])  
+             - 2. * eta[eqn_id] * eta[eqn_id] * (1. - eta[eqn_id])
+             + 4. * alpha * eta[eqn_id] * aval;
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double f(const double c, const double *eta)
+  {
+    // assumes that ca and cb are the same quanitity 
+    const double hh = h(eta);
+    return fa(c) * hh + fb(c) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double f(const double ca, const double cb, const double *eta)
+  {
+    const double hh = h(eta);
+    return fa(ca) * hh + fb(cb) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double df_dc(const double c, const double *eta)
+  {
+    // assumes that ca and cb are the same quanitity
+    const double hh = h(eta);
+    return dfa_dca(c) * hh + dfb_dcb(c) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  double df_dc(const double ca, const double cb, const double *eta)
+  {
+    // TODO: remove this function
+    // assumes that dca/dc = dcb/dc = 1, which is not true
+    // probably best to never use this function and use 
+    // eq 28 from KKS instead -- leaving it here for now
+    const double hh = h(eta);
+    return dfa_dca(ca) * hh + dfb_dcb(cb) * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  double d2f_dc2(const double *eta)
+  {
+    // assumes that ca and cb are the same quanitity
+    const double hh = h(eta);
+    return d2fa_dca2() * hh + d2fb_dcb2() * (1. - hh);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double df_deta(const double c, const double eta)
+  {
+    // assumes that ca and cb are the same quanitity
+    // and does **not** include the w g' term
+
+    // dh(eta1, eta2) / deta1 is a function of eta1 only
+    const double dhdeta = dh_deta(eta);
+    return fa(c) * dhdeta + fb(c) * (-dhdeta);
+  }
+
+  KOKKOS_INLINE_FUNCTION 
+  const double df_deta(const double ca, const double cb, const double eta)
+  {
+    // does not include the w g' term
+
+    // dh(eta1, eta2) / deta1 is a function of eta1 only
+    const double dhdeta = dh_deta(eta);
+    return fa(ca) * dhdeta + fb(cb) * (-dhdeta)
+             + dhdeta * dfb_dcb(cb) * (cb - ca);
+  }
+
+
+}  // namespace parabolicenergy
+
+
 namespace kks
 {
-  const int n_c_max = 4;
-  int n_c = 1;
+
+
+  // time
+  TUSAS_DEVICE const int Nt_max = 3;
+  
+  // c
+  TUSAS_DEVICE const int Nc_max = 2;
+  TUSAS_DEVICE int Nc = 1;
+  TUSAS_DEVICE int c_start_idx = 0;
+
+  // mu
+  TUSAS_DEVICE const int Nmu_max = 2;
+  TUSAS_DEVICE int Nmu = 1;
+  TUSAS_DEVICE int mu_start_idx = 1;
+
+  // eta
+  TUSAS_DEVICE const int Neta_max = 4;
+  TUSAS_DEVICE int Neta = 1;
+  TUSAS_DEVICE int eta_start_idx = 1;
+  
+  // parameters
+  TUSAS_DEVICE double t0 = 1.;
+  TUSAS_DEVICE double x0 = 1.;
+  TUSAS_DEVICE double f0 = 1.;
+  TUSAS_DEVICE double k_c = 0.;
+  TUSAS_DEVICE double k_eta = 1.5;
+  TUSAS_DEVICE double M = 10.;
+  TUSAS_DEVICE double L = 2.;
+  TUSAS_DEVICE double w = 12.;
+
+  PARAM_FUNC(param)
+  {
+    int Neta_ = plist->get<int>("N_ETA", Neta);
+    int Nc_ = plist->get<int>("N_C", Nc);
+#ifdef TUSAS_HAVE_CUDA
+    cudaMemcpyToSymbol(Neta, &Neta_, sizeof(int));
+    cudaMemcpyToSymbol(Nc, &c_, sizeof(int));
+#else
+    Neta = Neta_;
+    Neta = Nc_;
+#endif
+    if(Neta > Neta_max) exit(0);
+    if(Nc > Nc_max) exit(0);
+
+    // nondim free energy density, J/m^3
+    // generally, should be ~parabolicenergy::Aa_
+    f0 = plist->get<double>("f0", f0);
+    // nondim spatial scaling, m
+    x0 = plist->get<double>("x0", x0);
+    // nondim temporal scaling, s
+    t0 = plist->get<double>("t0", t0);
+
+    k_c = plist->get<double>("k_c", k_c);
+    k_eta = plist->get<double>("k_eta", k_eta);
+    M = plist->get<double>("M", M);
+    L = plist->get<double>("L", L);
+    w = plist->get<double>("w", w);
+
+    // set params for free energy density
+    parabolicenergy::param(plist);
+
+    // nondimensionalize
+    // note that if x0_, t0_, and f0_ are not
+    // set by the user in an input file, these
+    // values default to 1 and the original
+    // dimensional equations are preserved
+    parabolicenergy::Aa = parabolicenergy::Aa / f0;
+    parabolicenergy::Ab = parabolicenergy::Ab / f0;
+    parabolicenergy::f1 = parabolicenergy::f1 / f0;
+    parabolicenergy::f2 = parabolicenergy::f2 / f0;
+    k_c = k_c / x0 / x0 / f0;
+    k_eta = k_eta / x0 / x0 / f0;
+    M = M * t0 * f0 / x0 / x0;
+    L = L * t0 * f0;
+    w = w / f0;
+  }
+
+  /*
+   * residual for eta equations using the kks model
+   */
+  KOKKOS_INLINE_FUNCTION 
+  RES_FUNC_TPETRA(pde_eta, const double mobility(const double hh))
+  {
+    const int Nt = 3;
+
+    const int local_id = eqn_id - eta_start_idx;
+
+    const double phi = basis[0]->phi(i);
+    const double dphi_dx = basis[0]->dphidx(i);
+    const double dphi_dy = basis[0]->dphidy(i);
+    const double dphi_dz = basis[0]->dphidz(i);
+
+    double c[Nt_max * Nc_max];
+    double dc_dx[Nt_max * Nc_max];
+    double dc_dy[Nt_max * Nc_max];
+    double dc_dz[Nt_max * Nc_max];
+    tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
+    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
+
+    double eta[Nt_max * Neta_max];
+    double deta_dx[Nt_max * Neta_max];
+    double deta_dy[Nt_max * Neta_max];
+    double deta_dz[Nt_max * Neta_max];
+    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
+    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
+
+    double hh[Nt_max];
+    double ca[Nt_max];
+    double cb[Nt_max];
+    double k_divgrad_eta[Nt_max];
+    double df_deta[Nt_max];
+    double f[Nt_max];
+
+    int idx = 0;
+    for (int tdx = 0; tdx < Nt; ++tdx) {
+      hh[tdx] = parabolicenergy::h(&eta[tdx * Neta_max]);
+      
+      ca[tdx] = parabolicenergy::c1;
+      cb[tdx] = parabolicenergy::c2;
+      idx = tools::utils::idx(tdx, local_id, Nc_max);
+      tools::solvers::solve_kks(c[idx], hh[tdx], ca[tdx], cb[tdx],
+                                parabolicenergy::dfa_dca,
+                                parabolicenergy::dfb_dcb,
+                                parabolicenergy::d2fa_dca2,
+                                parabolicenergy::d2fb_dcb2);
+
+      idx = tools::utils::idx(tdx, local_id, Neta_max);
+      df_deta[tdx] = (parabolicenergy::df_deta(ca[tdx], cb[tdx], eta[idx])
+                        + w * parabolicenergy::dg_deta(&eta[tdx * Neta_max], local_id)) * phi;
+      k_divgrad_eta[tdx] = k_eta * (deta_dx[idx] * dphi_dx + deta_dy[idx] * dphi_dy + deta_dz[idx] * dphi_dz);
+
+      f[tdx] = L* (k_divgrad_eta[tdx] + df_deta[tdx]);
+    }
+
+    const double deta_dt = (eta[tools::utils::idx(0, local_id, Neta_max)] 
+                              - eta[tools::utils::idx(1, local_id, Neta_max)]) / dt_ * phi;
+
+    return tools::utils::ret_value(deta_dt, f, dt_, dtold_, t_theta_, t_theta2_);
+  }
+
+  /*
+   * residual for c equations (non-split) using the kks model
+   */
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(pde_c, const double mobility(const double hh))
+  {
+    // number of time levels to compute
+    // might want to pass this in to res func?
+    const int Nt = 3;
+
+    // test function
+    const double phi = basis[0]->phi(i);
+    // grad(phi)
+    const double dphi_dx = basis[0]->dphidx(i);
+    const double dphi_dy = basis[0]->dphidy(i);
+    const double dphi_dz = basis[0]->dphidz(i);
+
+    // populate c viewed as a "matrix"
+    //   c[time_idx, c_idx]
+    // but really a 1D array that
+    // we can index this using
+    //   utils::idx(time_idx, c_idx, Nc_max)
+    double c[Nt_max * Nc_max];
+    double dc_dx[Nt_max * Nc_max];
+    double dc_dy[Nt_max * Nc_max];
+    double dc_dz[Nt_max * Nc_max];
+    tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
+    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
+
+    // populate eta viewed as a "matrix"
+    //   eta[time_idx, eta_idx]
+    // but really a 1D array that
+    // we can index this using
+    //   utils::idx(time_idx, eta_idx, Neta_max)
+    double eta[Nt_max * Neta_max];
+    double deta_dx[Nt_max * Neta_max];
+    double deta_dy[Nt_max * Neta_max];
+    double deta_dz[Nt_max * Neta_max];
+    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
+    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
+
+    // define all the variables we need to calculate 
+    // the residual = Mdivgrad_df_dc
+    double hh[Nt_max];
+    double dh_dx[Nt_max];
+    double dh_dy[Nt_max];
+    double dh_dz[Nt_max];
+    double ca[Nt_max];
+    double cb[Nt_max];
+    double d2f_dc2[Nt_max];
+    double d2f_dcdx[Nt_max];
+    double d2f_dcdy[Nt_max];
+    double d2f_dcdz[Nt_max];
+    double Mdivgrad_df_dc[Nt_max];
+
+    // loop over each time level that we need data at
+    int idx = 0;
+    double dh_deta = 0;
+    for (int tdx = 0; tdx < Nt; ++tdx) {
+      // calculate h
+      hh[tdx] = parabolicenergy::h(&eta[tdx * Neta_max]);
+
+      // calculate grad h
+      dh_dx[tdx] = 0.;
+      dh_dy[tdx] = 0.;
+      dh_dz[tdx] = 0.;
+      for (int k = 0; k < Neta ; ++k) {
+        idx = tools::utils::idx(tdx, k, Neta_max);
+        dh_deta = parabolicenergy::dh_deta(eta[idx]);
+
+        dh_dx[tdx] += dh_deta * deta_dx[idx];
+        dh_dy[tdx] += dh_deta * deta_dy[idx];
+        dh_dz[tdx] += dh_deta * deta_dz[idx];
+      }
+
+      // do the kks solve to get ca and cb
+      // for the current component c_{eqn_id}
+      ca[tdx] = parabolicenergy::c1;
+      cb[tdx] = parabolicenergy::c2;
+      tools::solvers::solve_kks(c[tools::utils::idx(tdx, eqn_id, Nc_max)],
+                                hh[tdx],
+                                ca[tdx],
+                                cb[tdx],
+                                parabolicenergy::dfa_dca,
+                                parabolicenergy::dfb_dcb,
+                                parabolicenergy::d2fa_dca2,
+                                parabolicenergy::d2fb_dcb2);
+
+      // calculate d2f_dc2 using KKS eq 29 
+      d2f_dc2[tdx] = parabolicenergy::d2fa_dca2() * parabolicenergy::d2fb_dcb2() 
+                       / ((1 - hh[tdx]) * parabolicenergy::d2fa_dca2() + hh[tdx] * parabolicenergy::d2fb_dcb2());
+
+      // calculating grad(f_c) based on KKS eq 33, assuming M = D / f_cc
+      // this also follows from eq 30 and the chain rule
+      //   grad(f_c) = f_cc * h' * (cb - ca) * grad(eta) + f_cc * grad(c) 
+      //             = f_cc * (cb - ca) * grad(h) + f_cc * grad(c) 
+      idx = tools::utils::idx(tdx, eqn_id, Nc_max);
+      d2f_dcdx[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dx[tdx] + d2f_dc2[tdx] * dc_dx[idx];
+      d2f_dcdy[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dy[tdx] + d2f_dc2[tdx] * dc_dy[idx];
+      d2f_dcdz[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dz[tdx] + d2f_dc2[tdx] * dc_dz[idx];
+
+      // finally, calculate M * div(grad(f_c))
+      Mdivgrad_df_dc[tdx] = mobility(hh[tdx]) * (d2f_dcdx[tdx] * dphi_dx
+                                                 + d2f_dcdy[tdx] * dphi_dy
+                                                 + d2f_dcdz[tdx] * dphi_dz);
+    }  // tdx = 0, < Nt loop
+
+    const double dc_dt = (c[tools::utils::idx(0, eqn_id, Nc_max)] 
+                            - c[tools::utils::idx(1, eqn_id, Nc_max)]) / dt_ * phi;
+
+    return tools::utils::ret_value(dc_dt, Mdivgrad_df_dc, dt_, dtold_, t_theta_, t_theta2_);
+  }
+
+  /*
+   * preconditioner for eta equations using the kks model
+   */
+  KOKKOS_INLINE_FUNCTION 
+  PRE_FUNC_TPETRA(prec_eta)
+  {
+    const double phi_i = basis[0]->phi(i);
+    const double phi_j = basis[0]->phi(j);
+
+    const double dphi_dx_i = basis[0]->dphidx(i);
+    const double dphi_dy_i = basis[0]->dphidy(i);
+    const double dphi_dz_i = basis[0]->dphidz(i);
+    const double dphi_dx_j = basis[0]->dphidx(j);
+    const double dphi_dy_j = basis[0]->dphidy(j);
+    const double dphi_dz_j = basis[0]->dphidz(j);
+
+    const double divgrad = L * k_eta * (dphi_dx_i * dphi_dx_j 
+                                        + dphi_dy_i * dphi_dy_j 
+                                        + dphi_dz_i * dphi_dz_j);
+    const double ut = phi_i * phi_j / dt_;
+
+    return ut + t_theta_ * divgrad;
+  }
+
+  /*
+   * preconditioner for c equations (non-split) using the kks model
+   */
+  KOKKOS_INLINE_FUNCTION 
+  PRE_FUNC_TPETRA(prec_c, const double mobility(const double hh))
+  {
+    const double phi_i = basis[0]->phi(i);
+    const double phi_j = basis[0]->phi(j);
+
+    const double dphi_dx_i = basis[0]->dphidx(i);
+    const double dphi_dy_i = basis[0]->dphidy(i);
+    const double dphi_dz_i = basis[0]->dphidz(i);
+    const double dphi_dx_j = basis[0]->dphidx(j);
+    const double dphi_dy_j = basis[0]->dphidy(j);
+    const double dphi_dz_j = basis[0]->dphidz(j);
+    
+    double eta[Neta_max];
+    for(int k = 0; k < Neta; ++k){
+      eta[k] = basis[k + eta_start_idx]->uu();
+    }
+    
+    const double hh = parabolicenergy::h(eta);
+    // note that we can skip the kks solve here only
+    // because the free energy is parabolic -- the
+    // second derivatives are constant
+    const double d2f_dc2 = parabolicenergy::d2fa_dca2() * parabolicenergy::d2fb_dcb2() 
+                             / ((1 - hh) * parabolicenergy::d2fa_dca2() + hh * parabolicenergy::d2fb_dcb2());
+    const double Mdivgrad_c = mobility(hh) * d2f_dc2 * (dphi_dx_i * dphi_dx_j 
+                                                        + dphi_dy_i * dphi_dy_j 
+                                                        + dphi_dz_i * dphi_dz_j);
+    const double ut = phi_i * phi_j / dt_;
+
+    return ut + t_theta_ * Mdivgrad_c;
+  }
+
+
 }  // namespace kks
 
     

--- a/timestep/include/pdes.hpp
+++ b/timestep/include/pdes.hpp
@@ -345,15 +345,19 @@ namespace kks
   PARAM_FUNC(param)
   {
     int Neta_ = plist->get<int>("N_ETA", Neta);
+    int Nmu_ = plist->get<int>("N_ETA", Neta);
     int Nc_ = plist->get<int>("N_C", Nc);
 #ifdef TUSAS_HAVE_CUDA
     cudaMemcpyToSymbol(Neta, &Neta_, sizeof(int));
+    cudaMemcpyToSymbol(Nmu, &Nmu_, sizeof(int));
     cudaMemcpyToSymbol(Nc, &c_, sizeof(int));
 #else
     Neta = Neta_;
+    Nmu = Nmu_;
     Neta = Nc_;
 #endif
     if(Neta > Neta_max) exit(0);
+    if(Nmu > Nmu_max) exit(0);
     if(Nc > Nc_max) exit(0);
 
     // nondim free energy density, J/m^3
@@ -544,6 +548,97 @@ namespace kks
 
     return tools::utils::ret_value(dc_dt, Mdivgrad_df_dc, dt_, dtold_, t_theta_, t_theta2_);
   }
+  
+  /*
+   * residual for c equations (split) using the kks model
+   */
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(pde_c_split, const double mobility(const double hh))
+  {
+    // number of time levels to compute
+    // might want to pass this in to res func?
+    const int Nt = 3;
+
+    const int local_id = eqn_id - c_start_idx;
+
+    const double phi = basis[0]->phi(i);
+    Grad grad_phi;
+    grad_phi.dx = basis[0]->dphidx(i);
+    grad_phi.dy = basis[0]->dphidy(i);
+    grad_phi.dz = basis[0]->dphidz(i);
+
+    Grad grad_mu[Nt_max * Nmu_max];
+    tools::utils::get_graduu(grad_mu, Nmu, Nmu_max, mu_start_idx, basis);
+
+    double eta[Nt_max * Neta_max];
+    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
+
+    double hh;
+    double hdivgrad_mu[Nt_max];
+
+    int idx = 0;
+    for (int tdx = 0; tdx < Nt; ++tdx) {
+      // calculate h
+      hh = parabolicenergy::h(&eta[tdx * Neta_max]);
+
+      idx = tools::utils::idx(tdx, local_id, Nmu_max);
+      hdivgrad_mu[tdx] = mobility(hh) * grad_mu[idx] * grad_phi;
+    }  // tdx = 0, < Nt loop
+
+    const double dc_dt = (basis[eqn_id]->uu() - basis[eqn_id]->uuold()) / dt_ * phi;
+
+    return tools::utils::ret_value(dc_dt, hdivgrad_mu, dt_, dtold_, t_theta_, t_theta2_);
+  }
+  
+  /*
+   * residual for mu equations using the kks model
+   */
+  KOKKOS_INLINE_FUNCTION
+  RES_FUNC_TPETRA(pde_mu)
+  {
+    const int Nt = 1;
+
+    // note that c and mu share a local_id
+    const int local_id = eqn_id - mu_start_idx;
+
+    const double phi = basis[0]->phi(i);
+    Grad grad_phi;
+    grad_phi.dx = basis[0]->dphidx(i);
+    grad_phi.dy = basis[0]->dphidy(i);
+    grad_phi.dz = basis[0]->dphidz(i);
+
+    double c[Nt_max * Nc_max];
+    Grad grad_c[Nt_max * Nc_max];
+    tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
+    tools::utils::get_graduu(grad_c, Nc, Nc_max, c_start_idx, basis);
+
+    double eta[Nt_max * Neta_max];
+    tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
+
+    double hh, ca, cb;
+    double kdivgrad_c[Nt_max];
+    double df_dc[Nt_max];
+
+    int idx = 0;
+    for (int tdx = 0; tdx < Nt; ++tdx) {
+      idx = tools::utils::idx(tdx, local_id, Nc_max);
+      kdivgrad_c[tdx] = k_c * grad_c[idx] * grad_phi;
+
+      hh = parabolicenergy::h(&eta[tdx * Neta_max]);
+      ca = parabolicenergy::c1;
+      cb = parabolicenergy::c2;
+      tools::solvers::solve_kks(c[idx], hh, ca, cb,
+                                parabolicenergy::dfa_dca,
+                                parabolicenergy::dfb_dcb,
+                                parabolicenergy::d2fa_dca2,
+                                parabolicenergy::d2fb_dcb2);
+
+      df_dc[tdx] = parabolicenergy::dfa_dca(ca) * phi;
+    }  // tdx = 0, < Nt loop
+    
+    return -basis[eqn_id]->uu() * phi + df_dc[0] + kdivgrad_c[0];
+  }
+
 
   /*
    * preconditioner for eta equations using the kks model

--- a/timestep/include/pdes.hpp
+++ b/timestep/include/pdes.hpp
@@ -403,23 +403,20 @@ namespace kks
     const int local_id = eqn_id - eta_start_idx;
 
     const double phi = basis[0]->phi(i);
-    const double dphi_dx = basis[0]->dphidx(i);
-    const double dphi_dy = basis[0]->dphidy(i);
-    const double dphi_dz = basis[0]->dphidz(i);
+    Grad grad_phi;
+    grad_phi.dx = basis[0]->dphidx(i);
+    grad_phi.dy = basis[0]->dphidy(i);
+    grad_phi.dz = basis[0]->dphidz(i);
 
     double c[Nt_max * Nc_max];
-    double dc_dx[Nt_max * Nc_max];
-    double dc_dy[Nt_max * Nc_max];
-    double dc_dz[Nt_max * Nc_max];
+    Grad grad_c[Nt_max * Nc_max];
     tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
-    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
+    tools::utils::get_graduu(grad_c, Nc, Nc_max, c_start_idx, basis);
 
     double eta[Nt_max * Neta_max];
-    double deta_dx[Nt_max * Neta_max];
-    double deta_dy[Nt_max * Neta_max];
-    double deta_dz[Nt_max * Neta_max];
+    Grad grad_eta[Nt_max * Neta_max];
     tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
-    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
+    tools::utils::get_graduu(grad_eta, Neta, Neta_max, eta_start_idx, basis);
 
     double hh[Nt_max];
     double ca[Nt_max];
@@ -444,9 +441,9 @@ namespace kks
       idx = tools::utils::idx(tdx, local_id, Neta_max);
       df_deta[tdx] = (parabolicenergy::df_deta(ca[tdx], cb[tdx], eta[idx])
                         + w * parabolicenergy::dg_deta(&eta[tdx * Neta_max], local_id)) * phi;
-      k_divgrad_eta[tdx] = k_eta * (deta_dx[idx] * dphi_dx + deta_dy[idx] * dphi_dy + deta_dz[idx] * dphi_dz);
+      k_divgrad_eta[tdx] = k_eta * grad_eta[idx] * grad_phi;
 
-      f[tdx] = L* (k_divgrad_eta[tdx] + df_deta[tdx]);
+      f[tdx] = L * (k_divgrad_eta[tdx] + df_deta[tdx]);
     }
 
     const double deta_dt = (eta[tools::utils::idx(0, local_id, Neta_max)] 
@@ -467,10 +464,10 @@ namespace kks
 
     // test function
     const double phi = basis[0]->phi(i);
-    // grad(phi)
-    const double dphi_dx = basis[0]->dphidx(i);
-    const double dphi_dy = basis[0]->dphidy(i);
-    const double dphi_dz = basis[0]->dphidz(i);
+    Grad grad_phi;
+    grad_phi.dx = basis[0]->dphidx(i);
+    grad_phi.dy = basis[0]->dphidy(i);
+    grad_phi.dz = basis[0]->dphidz(i);
 
     // populate c viewed as a "matrix"
     //   c[time_idx, c_idx]
@@ -478,11 +475,9 @@ namespace kks
     // we can index this using
     //   utils::idx(time_idx, c_idx, Nc_max)
     double c[Nt_max * Nc_max];
-    double dc_dx[Nt_max * Nc_max];
-    double dc_dy[Nt_max * Nc_max];
-    double dc_dz[Nt_max * Nc_max];
+    Grad grad_c[Nt_max * Nc_max];
     tools::utils::get_uu(c, Nc, Nc_max, c_start_idx, basis);
-    tools::utils::get_graduu(dc_dx, dc_dy, dc_dz, Nc, Nc_max, c_start_idx, basis);
+    tools::utils::get_graduu(grad_c, Nc, Nc_max, c_start_idx, basis);
 
     // populate eta viewed as a "matrix"
     //   eta[time_idx, eta_idx]
@@ -490,44 +485,30 @@ namespace kks
     // we can index this using
     //   utils::idx(time_idx, eta_idx, Neta_max)
     double eta[Nt_max * Neta_max];
-    double deta_dx[Nt_max * Neta_max];
-    double deta_dy[Nt_max * Neta_max];
-    double deta_dz[Nt_max * Neta_max];
+    Grad grad_eta[Nt_max * Neta_max];
     tools::utils::get_uu(eta, Neta, Neta_max, eta_start_idx, basis);
-    tools::utils::get_graduu(deta_dx, deta_dy, deta_dz, Neta, Neta_max, eta_start_idx, basis);
+    tools::utils::get_graduu(grad_eta, Neta, Neta_max, eta_start_idx, basis);
 
     // define all the variables we need to calculate 
     // the residual = Mdivgrad_df_dc
     double hh[Nt_max];
-    double dh_dx[Nt_max];
-    double dh_dy[Nt_max];
-    double dh_dz[Nt_max];
+    Grad grad_h[Nt_max];
     double ca[Nt_max];
     double cb[Nt_max];
     double d2f_dc2[Nt_max];
-    double d2f_dcdx[Nt_max];
-    double d2f_dcdy[Nt_max];
-    double d2f_dcdz[Nt_max];
+    Grad grad_df_dc[Nt_max];
     double Mdivgrad_df_dc[Nt_max];
 
     // loop over each time level that we need data at
     int idx = 0;
-    double dh_deta = 0;
     for (int tdx = 0; tdx < Nt; ++tdx) {
       // calculate h
       hh[tdx] = parabolicenergy::h(&eta[tdx * Neta_max]);
 
       // calculate grad h
-      dh_dx[tdx] = 0.;
-      dh_dy[tdx] = 0.;
-      dh_dz[tdx] = 0.;
       for (int k = 0; k < Neta ; ++k) {
         idx = tools::utils::idx(tdx, k, Neta_max);
-        dh_deta = parabolicenergy::dh_deta(eta[idx]);
-
-        dh_dx[tdx] += dh_deta * deta_dx[idx];
-        dh_dy[tdx] += dh_deta * deta_dy[idx];
-        dh_dz[tdx] += dh_deta * deta_dz[idx];
+        grad_h[tdx] += parabolicenergy::dh_deta(eta[idx]) * grad_eta[idx];
       }
 
       // do the kks solve to get ca and cb
@@ -552,14 +533,10 @@ namespace kks
       //   grad(f_c) = f_cc * h' * (cb - ca) * grad(eta) + f_cc * grad(c) 
       //             = f_cc * (cb - ca) * grad(h) + f_cc * grad(c) 
       idx = tools::utils::idx(tdx, eqn_id, Nc_max);
-      d2f_dcdx[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dx[tdx] + d2f_dc2[tdx] * dc_dx[idx];
-      d2f_dcdy[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dy[tdx] + d2f_dc2[tdx] * dc_dy[idx];
-      d2f_dcdz[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * dh_dz[tdx] + d2f_dc2[tdx] * dc_dz[idx];
+      grad_df_dc[tdx] = d2f_dc2[tdx] * (cb[tdx] - ca[tdx]) * grad_h[tdx] + d2f_dc2[tdx] * grad_c[idx]; 
 
       // finally, calculate M * div(grad(f_c))
-      Mdivgrad_df_dc[tdx] = mobility(hh[tdx]) * (d2f_dcdx[tdx] * dphi_dx
-                                                 + d2f_dcdy[tdx] * dphi_dy
-                                                 + d2f_dcdz[tdx] * dphi_dz);
+      Mdivgrad_df_dc[tdx] = mobility(hh[tdx]) * grad_df_dc[tdx] * grad_phi;
     }  // tdx = 0, < Nt loop
 
     const double dc_dt = (c[tools::utils::idx(0, eqn_id, Nc_max)] 

--- a/timestep/include/pdes.hpp
+++ b/timestep/include/pdes.hpp
@@ -373,6 +373,9 @@ namespace kks
     // set params for free energy density
     parabolicenergy::param(plist);
 
+    // set params for solve_kks
+    tools::solvers::param(plist);
+
     // nondimensionalize
     // note that if x0_, t0_, and f0_ are not
     // set by the user in an input file, these

--- a/timestep/include/tools.hpp
+++ b/timestep/include/tools.hpp
@@ -22,7 +22,7 @@ namespace solvers
   double kks_tol = 1e-10;
   int kks_max_iter = 20;
 
-  PARAM_FUNC(param_)
+  PARAM_FUNC(param)
   {
     kks_tol = plist->get<double>("kks_tol", kks_tol); 
     kks_max_iter = plist->get<int>("kks_max_iter", kks_max_iter);

--- a/timestep/include/tools.hpp
+++ b/timestep/include/tools.hpp
@@ -11,6 +11,44 @@
 #define TOOLS_HPP
 
 
+typedef struct {
+  double dx = 0.;
+  double dy = 0.;
+  double dz = 0.;
+} Grad;
+
+double operator*(Grad const& lhs, Grad const& rhs) {
+  return lhs.dx * rhs.dx + lhs.dy * rhs.dy + lhs.dz * rhs.dz;
+}
+Grad operator+(Grad const& lhs, Grad const& rhs) {
+  Grad res;
+  res.dx = lhs.dx + rhs.dx;
+  res.dy = lhs.dy + rhs.dy;
+  res.dz = lhs.dz + rhs.dz;
+  return res;
+}
+Grad operator*(Grad const& lhs, const double rhs) {
+  Grad res;
+  res.dx = lhs.dx * rhs;
+  res.dy = lhs.dy * rhs;
+  res.dz = lhs.dz * rhs;
+  return res;
+}
+Grad operator*(const double lhs, Grad const& rhs) {
+  Grad res;
+  res.dx = rhs.dx * lhs;
+  res.dy = rhs.dy * lhs;
+  res.dz = rhs.dz * lhs;
+  return res;
+}
+Grad operator+=(Grad& lhs, Grad const& rhs) {
+  lhs.dx += rhs.dx;
+  lhs.dy += rhs.dy;
+  lhs.dz += rhs.dz;
+  return lhs;
+}
+
+
 namespace tools
 {
 
@@ -167,6 +205,28 @@ namespace utils
       duu_dz[idx(2, k, ncols)] = basis[k + first_idx]->duuoldolddz();
     }
   }
+
+  KOKKOS_INLINE_FUNCTION
+  void get_graduu(Grad* grad_uu,  // out: array to populate
+                  const int N_UU,  // in: number of uu to get
+                  const int ncols,  // in: number of "columns" in uu
+                  const int first_idx,  // in: index to start at
+                  GPUBasis* basis[]) {  // in: basis
+    for (int k = 0 ; k < N_UU; ++k) {
+      grad_uu[idx(0, k, ncols)].dx = basis[k + first_idx]->duudx();
+      grad_uu[idx(0, k, ncols)].dy = basis[k + first_idx]->duudy();
+      grad_uu[idx(0, k, ncols)].dz = basis[k + first_idx]->duudz();
+
+      grad_uu[idx(1, k, ncols)].dx = basis[k + first_idx]->duuolddx();
+      grad_uu[idx(1, k, ncols)].dy = basis[k + first_idx]->duuolddy();
+      grad_uu[idx(1, k, ncols)].dz = basis[k + first_idx]->duuolddz();
+
+      grad_uu[idx(2, k, ncols)].dx = basis[k + first_idx]->duuoldolddx();
+      grad_uu[idx(2, k, ncols)].dy = basis[k + first_idx]->duuoldolddy();
+      grad_uu[idx(2, k, ncols)].dz = basis[k + first_idx]->duuoldolddz();
+    }
+  }
+
 
   KOKKOS_INLINE_FUNCTION
   const double ret_value(const double ut,  // in: time derivative

--- a/timestep/include/tools.hpp
+++ b/timestep/include/tools.hpp
@@ -1,0 +1,198 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) Triad National Security, LLC.  This file is part of the
+//  Tusas code (LA-CC-17-001) and is subject to the revised BSD license terms
+//  in the LICENSE file found in the top-level directory of this distribution.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef TOOLS_HPP
+#define TOOLS_HPP
+
+
+namespace tools
+{
+
+
+namespace solvers
+{
+
+
+  double kks_tol = 1e-10;
+  int kks_max_iter = 20;
+
+  PARAM_FUNC(param_)
+  {
+    kks_tol = plist->get<double>("kks_tol", kks_tol); 
+    kks_max_iter = plist->get<int>("kks_max_iter", kks_max_iter);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const int solve_kks(const double &c1,  // in: c1
+                      const double &hh,  // in: h(eta)
+                      double &c1a,  // out: c1a, in, initial guess
+                      double &c1b,  // out: c1b, in: initial guess 
+                      const double DFA_DC1A(const double c1a),  // in: fa'(c1a)
+                      const double DFB_DC1B(const double c1b),  // in: fb'(c1b)
+                      const double D2FA_DC1A2(),  // in: fa''() [constant for now]
+                      const double D2FB_DC1B2(),  // in: fb''() [constant for now]
+                      const double &T = 0.)  // in: time
+  {
+    /*
+     * here, we are using notation similar to that in
+     * Tonks [10.1016/j.commatsci.2023.112375]:
+     *   a = phase a, corresponds to eta
+     *   b = phase b, corresponds to (1 - eta)
+     *   fa = free energy in phase a
+     *   fb = free energy in phase b
+     *   c1 = molar fraction of component 1
+     *   c1a = subset of c1 contained in phase a,
+     *         corresponds to h
+     *   c1b = subset of c1 contained in phase b,
+     *         corresponds to (1 - h)
+     * as implied above, note that
+     *   c1 = c1a * h + c1b * (1 - h)
+     */
+
+    // meta variables
+    double err2 = 0.;
+    double delta_c1b = 0.;
+    double delta_c1a = 0.;
+    const int max_iter = kks_max_iter;
+    const double tol = kks_tol;
+
+    // initial guess for c1a and c1b
+    c1a = hh * c1a;
+    c1b = (1 - hh) * c1b;
+
+    // terms for the kks solve
+    double d2fa_dc1a2 = (*D2FA_DC1A2)();
+    double d2fb_dc1b2 = (*D2FB_DC1B2)();
+    double f1 = hh * c1a + (1 - hh) * c1b - c1;
+    double f2 = (*DFA_DC1A)(c1a) - (*DFB_DC1B)(c1b);
+
+    /* 
+     * newton iteration loop
+     * the function we are finding the roots (ca, cb) of is
+     *   F = [ hh * c1a - (1 - hh) * c1b - c1,
+     *         dfa_dc1a(c1a) - dfb_dc1b(c1b) ]
+     * the jacobian in this case is
+     *   J = [[ hh,          (1 - hh) ],
+     *        [ d2fa_dc1a2,  -d2fb_dc1b2 ]]
+     * so, the inverse is
+     *   J^-1 = [[ -d2fb_dc1b2,  -(1 - hh) ],
+     *           [ d2fa_dc1a2,   hh ]] / det(J)
+     * then,
+     *   delta = -J^-1 @ F 
+     */
+    for (int i = 0; i < max_iter; ++i) {
+      // det(J)
+      const double detjac = -hh * d2fb_dc1b2 - (1 - hh) * d2fa_dc1a2;
+
+      // -J^-1 @ F
+      delta_c1a = -(-d2fb_dc1b2 * f1 - (1 - hh) * f2) / detjac;
+      delta_c1b = -(-d2fa_dc1a2 * f1 + hh * f2) / detjac;
+
+      // new value for (c1a, c1b)
+      c1a += delta_c1a;
+      c1b += delta_c1b;
+
+      // recalculate subset of terms for next iteration
+      f1 = hh * c1a + (1 - hh) * c1b - c1;
+      f2 = (*DFA_DC1A)(c1a) - (*DFB_DC1B)(c1b);
+
+      // check error and return if done
+      err2 = f1 * f1 + f2 * f2;
+      if (err2 < tol * tol) return 0;
+
+      // recalculate remaining terms for next iteration
+      d2fa_dc1a2 = (*D2FA_DC1A2)();
+      d2fb_dc1b2 = (*D2FB_DC1B2)();
+    }
+
+    // max iters exceeded
+    std::cout << "#### solve_kks() failed to converge!" << std::endl
+              << "#### current error = " << std::sqrt(err2) << std::endl
+              << "#### tol = " << tol << std::endl;
+    exit(-1);
+  }
+
+
+}  // namespace solvers
+
+
+namespace utils
+{
+
+
+  KOKKOS_INLINE_FUNCTION
+  int idx(const int i, const int j, const int ncols) {
+    // row-major ordering
+    return i * ncols + j;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void get_uu(double* uu,  // out: the array to populate
+              const int N_UU,  // in: number of uu to get
+              const int ncols,  // in: number of "columns" in uu
+              const int first_idx,  // in: index to start at
+              GPUBasis* basis[]) {  // in: basis
+      for (int k = 0 ; k < N_UU; ++k) {
+      uu[idx(0, k, ncols)] = basis[k + first_idx]->uu();
+      uu[idx(1, k, ncols)] = basis[k + first_idx]->uuold();
+      uu[idx(2, k, ncols)] = basis[k + first_idx]->uuoldold();
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void get_graduu(double* duu_dx,  // out: dx array to populate
+                  double* duu_dy,  // out: dy array to populate
+                  double* duu_dz,  // out: dz array to populate
+                  const int N_UU,  // in: number of uu to get
+                  const int ncols,  // in: number of "columns" in uu
+                  const int first_idx,  // in: index to start at
+                  GPUBasis* basis[]) {  // in: basis
+    for (int k = 0 ; k < N_UU; ++k) {
+      duu_dx[idx(0, k, ncols)] = basis[k + first_idx]->duudx();
+      duu_dy[idx(0, k, ncols)] = basis[k + first_idx]->duudy();
+      duu_dz[idx(0, k, ncols)] = basis[k + first_idx]->duudz();
+
+      duu_dx[idx(1, k, ncols)] = basis[k + first_idx]->duuolddx();
+      duu_dy[idx(1, k, ncols)] = basis[k + first_idx]->duuolddy();
+      duu_dz[idx(1, k, ncols)] = basis[k + first_idx]->duuolddz();
+
+      duu_dx[idx(2, k, ncols)] = basis[k + first_idx]->duuoldolddx();
+      duu_dy[idx(2, k, ncols)] = basis[k + first_idx]->duuoldolddy();
+      duu_dz[idx(2, k, ncols)] = basis[k + first_idx]->duuoldolddz();
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  const double ret_value(const double ut,  // in: time derivative
+                         const double* f,  // in: residual
+                         const double dt,  // in: current dt
+                         const double dtold,  // in: previous dt
+                         const double t_theta,  // in: implicit/explicit weight
+                         const double t_theta2) {  // in: adaptive time-step control
+    return ut + (1. - t_theta2) * t_theta * f[0]
+             + (1. - t_theta2) * (1. - t_theta) * f[1]
+             + .5 * t_theta2 * ((2. + dt / dtold) * f[1] - dt / dtold * f[2]);
+  } 
+
+  KOKKOS_INLINE_FUNCTION
+  const double ret_value(const double ut,  // in: time derivative
+                         const double* f,  // in: residual
+                         const double t_theta) {  //: in implicit/explicit weight
+    return ut + t_theta * f[0] + (1. - t_theta) * f[1];
+  }
+
+
+}  // namespace utils
+
+    
+}  // namespace tools
+
+
+#endif  // ifndef TOOLS_HPP
+


### PR DESCRIPTION
This PR starts the work of transferring case definitions from `function_def.hpp` to three separate files to reduce boilerplate code and for readability.

- `tools.hpp` contains helper utilities and solvers
- `pdes.hpp` contains the base PDEs shared by individual cases
- `cases.hpp` contains definitions specific to individual test cases

Currently `tonks1kks` and `tonks1splitkks` have been ported to the new format. A partial port for `shengsplitkks` is also included, but is not confirmed to be working yet -- possibly due to scaling issues.